### PR TITLE
Add automatic version update notification feature

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -89,11 +89,34 @@ export namespace wailsapp {
 		}
 	}
 	
+	export class VersionCheckDTO {
+	    hasUpdate: boolean;
+	    latestVersion?: string;
+	    currentVersion: string;
+	    releaseUrl?: string;
+	    checkedAt: string;
+	    error?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new VersionCheckDTO(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.hasUpdate = source["hasUpdate"];
+	        this.latestVersion = source["latestVersion"];
+	        this.currentVersion = source["currentVersion"];
+	        this.releaseUrl = source["releaseUrl"];
+	        this.checkedAt = source["checkedAt"];
+	        this.error = source["error"];
+	    }
+	}
 	export class AppInfoDTO {
 	    version: string;
 	    buildTime: string;
 	    fipsEnabled: boolean;
 	    fipsStatus: string;
+	    versionCheck?: VersionCheckDTO;
 	
 	    static createFrom(source: any = {}) {
 	        return new AppInfoDTO(source);
@@ -105,7 +128,26 @@ export namespace wailsapp {
 	        this.buildTime = source["buildTime"];
 	        this.fipsEnabled = source["fipsEnabled"];
 	        this.fipsStatus = source["fipsStatus"];
+	        this.versionCheck = this.convertValues(source["versionCheck"], VersionCheckDTO);
 	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class AutoDownloadValidationDTO {
 	    customFieldsEnabled: boolean;

--- a/frontend/wailsjs/go/wailsapp/App.d.ts
+++ b/frontend/wailsjs/go/wailsapp/App.d.ts
@@ -12,6 +12,8 @@ export function CancelTransfer(arg1:string):Promise<void>;
 
 export function CheckFolderExistsForUpload(arg1:string,arg2:string):Promise<wailsapp.FolderExistsCheckDTO>;
 
+export function CheckForUpdates():Promise<wailsapp.VersionCheckDTO>;
+
 export function ClearCatalogCache():Promise<void>;
 
 export function ClearCompletedTransfers():Promise<void>;

--- a/frontend/wailsjs/go/wailsapp/App.js
+++ b/frontend/wailsjs/go/wailsapp/App.js
@@ -22,6 +22,10 @@ export function CheckFolderExistsForUpload(arg1, arg2) {
   return window['go']['wailsapp']['App']['CheckFolderExistsForUpload'](arg1, arg2);
 }
 
+export function CheckForUpdates() {
+  return window['go']['wailsapp']['App']['CheckForUpdates']();
+}
+
 export function ClearCatalogCache() {
   return window['go']['wailsapp']['App']['ClearCatalogCache']();
 }

--- a/internal/wailsapp/version_bindings.go
+++ b/internal/wailsapp/version_bindings.go
@@ -1,0 +1,218 @@
+// Package wailsapp provides version checking Wails bindings.
+package wailsapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rescale/rescale-int/internal/http"
+	"github.com/rescale/rescale-int/internal/version"
+)
+
+// VersionCheckDTO contains version update information
+type VersionCheckDTO struct {
+	HasUpdate      bool   `json:"hasUpdate"`
+	LatestVersion  string `json:"latestVersion,omitempty"`
+	CurrentVersion string `json:"currentVersion"`
+	ReleaseURL     string `json:"releaseUrl,omitempty"`
+	CheckedAt      string `json:"checkedAt"`       // ISO timestamp
+	Error          string `json:"error,omitempty"` // If check failed
+}
+
+// versionCache holds the cached version check result
+type versionCache struct {
+	mu         sync.RWMutex
+	result     VersionCheckDTO
+	lastCheck  time.Time
+	cacheValid bool
+}
+
+var (
+	versionCheckCache = &versionCache{}
+	cacheDuration     = 24 * time.Hour
+)
+
+// GitHubRelease represents the GitHub API response structure
+type GitHubRelease struct {
+	TagName string `json:"tag_name"` // e.g., "v4.7.0"
+	HTMLURL string `json:"html_url"` // e.g., "https://github.com/rescale-labs/Rescale_Interlink/releases/tag/v4.7.0"
+}
+
+// CheckForUpdates checks GitHub for newer releases.
+// Returns cached result if checked within last 24 hours.
+// This function respects proxy configuration and times out after 5 seconds.
+func (a *App) CheckForUpdates() VersionCheckDTO {
+	a.logInfo("version", "Checking for updates...")
+
+	// Check cache first
+	versionCheckCache.mu.RLock()
+	if versionCheckCache.cacheValid && time.Since(versionCheckCache.lastCheck) < cacheDuration {
+		a.logInfo("version", "Using cached version check result")
+		result := versionCheckCache.result
+		versionCheckCache.mu.RUnlock()
+		return result
+	}
+	versionCheckCache.mu.RUnlock()
+
+	// Create result DTO with current version
+	result := VersionCheckDTO{
+		HasUpdate:      false,
+		CurrentVersion: version.Version,
+		CheckedAt:      time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Channel to receive result from worker goroutine
+	resultChan := make(chan VersionCheckDTO, 1)
+
+	// Run the API call in a goroutine with timeout
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Create HTTP client respecting proxy configuration
+		httpClient, err := http.ConfigureHTTPClient(a.config)
+		if err != nil {
+			a.logError("version", fmt.Sprintf("Failed to create HTTP client: %v", err))
+			result.Error = fmt.Sprintf("HTTP client error: %v", err)
+			resultChan <- result
+			return
+		}
+
+		// GitHub API endpoint for latest release
+		url := "https://api.github.com/repos/rescale-labs/Rescale_Interlink/releases/latest"
+
+		// Create request with context
+		req, err := nethttp.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			a.logError("version", fmt.Sprintf("Failed to create request: %v", err))
+			result.Error = fmt.Sprintf("Request creation error: %v", err)
+			resultChan <- result
+			return
+		}
+
+		// Set User-Agent header (GitHub API best practice)
+		req.Header.Set("User-Agent", fmt.Sprintf("Rescale-Interlink/%s", version.Version))
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+		// Execute request
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			a.logError("version", fmt.Sprintf("GitHub API request failed: %v", err))
+			result.Error = fmt.Sprintf("Network error: %v", err)
+			resultChan <- result
+			return
+		}
+		defer resp.Body.Close()
+
+		// Check response status
+		if resp.StatusCode != 200 {
+			a.logError("version", fmt.Sprintf("GitHub API returned status %d", resp.StatusCode))
+			result.Error = fmt.Sprintf("GitHub API error: status %d", resp.StatusCode)
+			resultChan <- result
+			return
+		}
+
+		// Parse JSON response
+		var release GitHubRelease
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			a.logError("version", fmt.Sprintf("Failed to read response: %v", err))
+			result.Error = fmt.Sprintf("Response read error: %v", err)
+			resultChan <- result
+			return
+		}
+
+		if err := json.Unmarshal(body, &release); err != nil {
+			a.logError("version", fmt.Sprintf("Failed to parse JSON: %v", err))
+			result.Error = fmt.Sprintf("JSON parse error: %v", err)
+			resultChan <- result
+			return
+		}
+
+		// Compare versions
+		result.LatestVersion = release.TagName
+		result.ReleaseURL = release.HTMLURL
+
+		if compareVersions(version.Version, release.TagName) < 0 {
+			result.HasUpdate = true
+			a.logInfo("version", fmt.Sprintf("Update available: %s -> %s", version.Version, release.TagName))
+		} else {
+			a.logInfo("version", fmt.Sprintf("Current version %s is up to date", version.Version))
+		}
+
+		resultChan <- result
+	}()
+
+	// Wait for result or timeout
+	select {
+	case result = <-resultChan:
+		// Success or handled error
+	case <-time.After(6 * time.Second):
+		a.logError("version", "Version check timed out after 6 seconds")
+		result.Error = "Request timed out"
+	}
+
+	// Cache the result
+	versionCheckCache.mu.Lock()
+	versionCheckCache.result = result
+	versionCheckCache.lastCheck = time.Now()
+	versionCheckCache.cacheValid = true
+	versionCheckCache.mu.Unlock()
+
+	return result
+}
+
+// compareVersions compares two semantic version strings.
+// Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
+// Strips 'v' prefix and compares major.minor.patch numerically.
+// Handles development versions (e.g., v4.6.8-dev) by stripping suffix.
+func compareVersions(v1, v2 string) int {
+	// Strip 'v' prefix
+	v1 = strings.TrimPrefix(v1, "v")
+	v2 = strings.TrimPrefix(v2, "v")
+
+	// Strip any suffix after hyphen (e.g., "-dev", "-beta")
+	if idx := strings.Index(v1, "-"); idx != -1 {
+		v1 = v1[:idx]
+	}
+	if idx := strings.Index(v2, "-"); idx != -1 {
+		v2 = v2[:idx]
+	}
+
+	// Split into parts
+	parts1 := strings.Split(v1, ".")
+	parts2 := strings.Split(v2, ".")
+
+	// Compare each part numerically
+	maxLen := len(parts1)
+	if len(parts2) > maxLen {
+		maxLen = len(parts2)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var p1, p2 int
+
+		if i < len(parts1) {
+			p1, _ = strconv.Atoi(parts1[i])
+		}
+		if i < len(parts2) {
+			p2, _ = strconv.Atoi(parts2[i])
+		}
+
+		if p1 < p2 {
+			return -1
+		}
+		if p1 > p2 {
+			return 1
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
  Feature: Automatic Version Update Notification

  Summary

  Adds automatic checking for new releases on GitHub with a user-friendly notification badge in the UI.
<img width="1318" height="749" alt="image" src="https://github.com/user-attachments/assets/fa7a7b84-2b30-43de-bdba-bcbf62a188d4" />

  Changes

  - ✅ Automatic version check on app startup (non-blocking, 2-second delay)
  - ✅ Yellow notification badge displays when new version available
  - ✅ Badge is clickable and opens GitHub releases page
  - ✅ 24-hour caching to prevent API rate limits
  - ✅ Semantic version comparison (handles v4.6.8, v4.7.0, dev versions, etc.)
  - ✅ Proxy configuration support
  - ✅ FIPS 140-3 compliance maintained

  Implementation Details

  Backend:
  - Added internal/wailsapp/version_bindings.go with CheckForUpdates() function
  - GitHub API integration: GET /repos/rescale-labs/Rescale_Interlink/releases/latest
  - Semantic version comparison with support for dev/beta suffixes
  - In-memory caching with 24-hour expiry
  - 5-second timeout for network calls
  - Updated AppInfoDTO to include optional VersionCheck field

  Frontend:
  - Updated TypeScript type definitions (models.ts, App.d.ts, App.js)
  - Modified App.tsx header to display update badge below version number
  - Uses Wails BrowserOpenURL() for opening external links
  - Added useEffect hook to trigger version check after app loads

  User Experience

  - Badge appears ~2 seconds after app startup (non-blocking)
  - Shows "Update available: vX.Y.Z →" in yellow
  - Clicking badge opens GitHub releases page in browser
  - Badge only shown when newer version detected
  - Cached results persist for 24 hours

  Testing

  - Built and tested on macOS arm64 with FIPS 140-3
  - Verified badge appears when simulating older version (v4.6.7 → v4.6.8)
  - Confirmed clicking badge opens GitHub releases in browser
  - Tested version comparison logic (10 test cases passed)
  - Verified caching behavior
  - Tested error handling (network failures handled gracefully)

  Files Changed

  Backend:
  - internal/wailsapp/version_bindings.go (NEW - 204 lines)
  - internal/wailsapp/config_bindings.go (modified)

  Frontend:
  - frontend/src/App.tsx (modified)
  - frontend/wailsjs/go/models.ts (modified)
  - frontend/wailsjs/go/wailsapp/App.d.ts (modified)
  - frontend/wailsjs/go/wailsapp/App.js (modified)

  Technical Notes

  - Uses GitHub API (unauthenticated) with 60 requests/hour rate limit
  - Cache prevents rate limit issues under normal usage
  - Respects existing proxy configuration via http.ConfigureHTTPClient()
  - No new dependencies added
  - Follows existing codebase patterns and conventions

  Future Enhancements (Optional)

  - Could add user preference to disable update checks
  - Could add "dismiss" option for specific version
  - Could show release notes in tooltip