### PR TITLE
Bearer auth for JWT API keys + dev/staging platform allowlist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,19 @@ LINUX_AMD64_DIR := $(BIN_DIR)/linux-amd64
 WINDOWS_AMD64_DIR := $(BIN_DIR)/windows-amd64
 WINDOWS_AMD64_MESA_DIR := $(BIN_DIR)/windows-amd64-mesa
 
+# Internal-build output directories (dev/staging platform URLs enabled).
+# These live alongside production output under bin/$(VERSION)/ with an
+# -internal suffix so they cannot be mistaken for release artifacts and
+# are never packaged by `make package`.
+DARWIN_ARM64_INTERNAL_DIR := $(BIN_DIR)/darwin-arm64-internal
+LINUX_AMD64_INTERNAL_DIR := $(BIN_DIR)/linux-amd64-internal
+WINDOWS_AMD64_INTERNAL_DIR := $(BIN_DIR)/windows-amd64-internal
+
+# Internal-build ldflags: same as LDFLAGS but appends "-internal" to the
+# reported version so `rescale-int --version` self-identifies as a non-
+# production build.
+LDFLAGS_INTERNAL := -ldflags "-s -w -X github.com/rescale/rescale-int/internal/version.Version=$(VERSION)-internal -X github.com/rescale/rescale-int/internal/version.BuildTime=$(BUILD_TIME)"
+
 # Default target
 .PHONY: all
 all: build
@@ -94,6 +107,35 @@ build-windows-amd64-mesa:
 	@cp cmd/rescale-int/rescale-int.manifest $(WINDOWS_AMD64_MESA_DIR)/$(BINARY_NAME).exe.manifest 2>/dev/null || true
 	@cp cmd/rescale-int/rescale-int.exe.local $(WINDOWS_AMD64_MESA_DIR)/$(BINARY_NAME).exe.local 2>/dev/null || true
 	@echo "✅ Built: $(WINDOWS_AMD64_MESA_DIR)/$(BINARY_NAME).exe [FIPS 140-3] (Mesa software rendering)"
+
+# =============================================================================
+# Internal builds (dev/staging platform URLs enabled, -internal version tag)
+# =============================================================================
+# Internal builds compile with `-tags internal` (Go) and `--mode internal`
+# (Vite) so the dev/staging platform URLs are reachable in the allowlist
+# and the GUI dropdown. Use for hand-distributed builds to contributors
+# testing against non-production tenants. NEVER package or release.
+
+.PHONY: build-internal-darwin-arm64
+build-internal-darwin-arm64:
+	@echo "Building macOS Apple Silicon INTERNAL binary [FIPS 140-3] (tags=internal)..."
+	@mkdir -p $(DARWIN_ARM64_INTERNAL_DIR)
+	@$(CGO_LDFLAGS_MACOS) $(GOFIPS) GOOS=darwin GOARCH=arm64 go build -tags internal $(LDFLAGS_INTERNAL) -o $(DARWIN_ARM64_INTERNAL_DIR)/$(BINARY_NAME) ./cmd/rescale-int
+	@echo "✅ Built: $(DARWIN_ARM64_INTERNAL_DIR)/$(BINARY_NAME) [FIPS 140-3, INTERNAL]"
+
+.PHONY: build-internal-linux-amd64
+build-internal-linux-amd64:
+	@echo "Building Linux AMD64 INTERNAL binary [FIPS 140-3] (tags=internal)..."
+	@mkdir -p $(LINUX_AMD64_INTERNAL_DIR)
+	@$(GOFIPS) GOOS=linux GOARCH=amd64 go build -tags internal $(LDFLAGS_INTERNAL) -o $(LINUX_AMD64_INTERNAL_DIR)/$(BINARY_NAME) ./cmd/rescale-int
+	@echo "✅ Built: $(LINUX_AMD64_INTERNAL_DIR)/$(BINARY_NAME) [FIPS 140-3, INTERNAL]"
+
+.PHONY: build-internal-windows-amd64
+build-internal-windows-amd64:
+	@echo "Building Windows AMD64 INTERNAL binary [FIPS 140-3] (tags=internal)..."
+	@mkdir -p $(WINDOWS_AMD64_INTERNAL_DIR)
+	@$(GOFIPS) GOOS=windows GOARCH=amd64 go build -tags internal $(LDFLAGS_INTERNAL) -o $(WINDOWS_AMD64_INTERNAL_DIR)/$(BINARY_NAME).exe ./cmd/rescale-int
+	@echo "✅ Built: $(WINDOWS_AMD64_INTERNAL_DIR)/$(BINARY_NAME).exe [FIPS 140-3, INTERNAL]"
 
 # Build all Windows variants
 .PHONY: build-windows-all
@@ -293,6 +335,11 @@ help:
 	@echo "  build-windows-amd64-mesa Build Windows AMD64 binary (Mesa software rendering)"
 	@echo "  build-windows-all       Build both Windows variants"
 	@echo "  build-all               Build all platform binaries (including both Windows variants)"
+	@echo ""
+	@echo "Internal Build Targets (dev/staging URLs enabled — NEVER release):"
+	@echo "  build-internal-darwin-arm64    macOS Apple Silicon internal binary"
+	@echo "  build-internal-linux-amd64     Linux AMD64 internal binary"
+	@echo "  build-internal-windows-amd64   Windows AMD64 internal binary"
 	@echo ""
 	@echo "Release Targets:"
 	@echo "  package                 Create release archives in dist/"

--- a/frontend/.env.internal
+++ b/frontend/.env.internal
@@ -1,0 +1,5 @@
+# Internal-build environment flags.
+# Loaded by Vite only when invoked with `--mode internal` (see
+# Makefile: build-internal-* targets). Production builds use the
+# default mode and do NOT see this file.
+VITE_INCLUDE_INTERNAL_URLS=true

--- a/frontend/src/components/tabs/SetupTab.tsx
+++ b/frontend/src/components/tabs/SetupTab.tsx
@@ -63,7 +63,10 @@ const isFRMPlatform = (url: string): boolean => {
   } catch { return false; }
 };
 
-// Must stay in sync with internal/config/platforms.go AllowedPlatformURLs
+// Must stay in sync with internal/config/platforms.go AllowedPlatformURLs.
+// Dev/staging entries are gated behind VITE_INCLUDE_INTERNAL_URLS (set only
+// by Vite's `internal` mode); production bundles exclude them via dead-code
+// elimination so they never appear in a release-shipped dropdown.
 const PLATFORM_URLS = [
   { value: 'https://platform.rescale.com', label: 'North America (platform.rescale.com)' },
   { value: 'https://kr.rescale.com', label: 'Korea (kr.rescale.com)' },
@@ -71,8 +74,12 @@ const PLATFORM_URLS = [
   { value: 'https://eu.rescale.com', label: 'Europe (eu.rescale.com)' },
   { value: 'https://itar.rescale.com', label: 'US ITAR (itar.rescale.com)' },
   { value: 'https://itar.rescale-gov.com', label: 'US ITAR FRM (itar.rescale-gov.com)' },
-  { value: 'https://platform-stage.rescale.com', label: 'Staging (platform-stage.rescale.com)' },
-  { value: 'https://platform-dev.rescale.com', label: 'Dev (platform-dev.rescale.com)' },
+  ...(import.meta.env.VITE_INCLUDE_INTERNAL_URLS === 'true'
+    ? [
+        { value: 'https://platform-stage.rescale.com', label: 'Staging (platform-stage.rescale.com)' },
+        { value: 'https://platform-dev.rescale.com', label: 'Dev (platform-dev.rescale.com)' },
+      ]
+    : []),
 ] as const;
 
 export function SetupTab() {

--- a/frontend/src/components/tabs/SetupTab.tsx
+++ b/frontend/src/components/tabs/SetupTab.tsx
@@ -71,6 +71,8 @@ const PLATFORM_URLS = [
   { value: 'https://eu.rescale.com', label: 'Europe (eu.rescale.com)' },
   { value: 'https://itar.rescale.com', label: 'US ITAR (itar.rescale.com)' },
   { value: 'https://itar.rescale-gov.com', label: 'US ITAR FRM (itar.rescale-gov.com)' },
+  { value: 'https://platform-stage.rescale.com', label: 'Staging (platform-stage.rescale.com)' },
+  { value: 'https://platform-dev.rescale.com', label: 'Dev (platform-dev.rescale.com)' },
 ] as const;
 
 export function SetupTab() {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_INCLUDE_INTERNAL_URLS?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -54,6 +54,17 @@ func (l *retryLogger) Warn(msg string, keysAndValues ...interface{}) {
 	}
 }
 
+// authScheme picks the Authorization scheme for a Rescale API key.
+// Legacy long-lived API tokens use "Token"; short-lived session JWTs
+// (three dot-separated base64url segments starting with "ey") use "Bearer".
+func authScheme(apiKey string) string {
+	parts := strings.Split(apiKey, ".")
+	if len(parts) == 3 && strings.HasPrefix(parts[0], "ey") {
+		return "Bearer"
+	}
+	return "Token"
+}
+
 // getStringField safely extracts a string value from a map[string]interface{}
 // Returns empty string and logs a warning if the key is missing or not a string
 func getStringField(m map[string]interface{}, key string, context string) string {
@@ -329,7 +340,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	}
 
 	// Add headers
-	req.Header.Set("Authorization", "Token "+c.apiKey)
+	req.Header.Set("Authorization", authScheme(c.apiKey)+" "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	// Note: Go's http.Transport automatically handles Accept-Encoding: gzip

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -50,6 +50,66 @@ func TestNewClientAcceptsValidBaseURL(t *testing.T) {
 	}
 }
 
+// TestAuthScheme_TokenForLegacyKeys verifies legacy API tokens continue to use "Token".
+func TestAuthScheme_TokenForLegacyKeys(t *testing.T) {
+	cases := []string{
+		"abc123def456",
+		"legacy-api-key-no-dots",
+		"two.segment.key-but-not-ey-prefixed",
+		"",
+	}
+	for _, k := range cases {
+		if got := authScheme(k); got != "Token" {
+			t.Errorf("authScheme(%q) = %q, want Token", k, got)
+		}
+	}
+}
+
+// TestAuthScheme_BearerForJWT verifies JWT-shaped keys switch to "Bearer".
+// Rescale session JWTs are three dot-separated base64url segments with the
+// header starting with "ey" (base64 of '{"').
+func TestAuthScheme_BearerForJWT(t *testing.T) {
+	jwt := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature"
+	if got := authScheme(jwt); got != "Bearer" {
+		t.Errorf("authScheme(jwt) = %q, want Bearer", got)
+	}
+}
+
+// TestDoRequest_AuthorizationHeader verifies the request actually sends the
+// correct scheme end-to-end for both key shapes.
+func TestDoRequest_AuthorizationHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		apiKey string
+		want   string
+	}{
+		{"legacy token", "abc123", "Token abc123"},
+		{"jwt bearer", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.sig", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.sig"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotAuth string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("{}"))
+			}))
+			defer server.Close()
+
+			client := NewClientForTest(&config.Config{
+				APIBaseURL: server.URL,
+				APIKey:     tc.apiKey,
+				ProxyMode:  "no-proxy",
+			})
+			_, _ = client.doRequest(context.Background(), "GET", "/api/v3/ping/", nil)
+
+			if gotAuth != tc.want {
+				t.Errorf("Authorization header = %q, want %q", gotAuth, tc.want)
+			}
+		})
+	}
+}
+
 // newTestClient creates a Client pointing at the given test server URL.
 // Delegates to NewClientForTest to avoid duplicating Client construction.
 func newTestClient(t *testing.T, serverURL string) *Client {

--- a/internal/config/platforms.go
+++ b/internal/config/platforms.go
@@ -23,6 +23,8 @@ var AllowedPlatformURLs = []PlatformURL{
 	{URL: "https://eu.rescale.com", Label: "Europe"},
 	{URL: "https://itar.rescale.com", Label: "US ITAR"},
 	{URL: "https://itar.rescale-gov.com", Label: "US ITAR FRM"},
+	{URL: "https://platform-stage.rescale.com", Label: "Staging"},
+	{URL: "https://platform-dev.rescale.com", Label: "Dev"},
 }
 
 // DefaultPlatformURL is the default platform for new configurations.

--- a/internal/config/platforms.go
+++ b/internal/config/platforms.go
@@ -16,6 +16,8 @@ type PlatformURL struct {
 // AllowedPlatformURLs is the authoritative list of valid Rescale platform URLs.
 // This list must stay in sync with the GUI dropdown in
 // frontend/src/components/tabs/SetupTab.tsx (PLATFORM_URLS constant).
+// Additional non-production endpoints may be appended by build-tagged files
+// (see platforms_internal.go, gated by `//go:build internal`).
 var AllowedPlatformURLs = []PlatformURL{
 	{URL: "https://platform.rescale.com", Label: "North America"},
 	{URL: "https://kr.rescale.com", Label: "Korea"},
@@ -23,8 +25,6 @@ var AllowedPlatformURLs = []PlatformURL{
 	{URL: "https://eu.rescale.com", Label: "Europe"},
 	{URL: "https://itar.rescale.com", Label: "US ITAR"},
 	{URL: "https://itar.rescale-gov.com", Label: "US ITAR FRM"},
-	{URL: "https://platform-stage.rescale.com", Label: "Staging"},
-	{URL: "https://platform-dev.rescale.com", Label: "Dev"},
 }
 
 // DefaultPlatformURL is the default platform for new configurations.

--- a/internal/config/platforms_internal.go
+++ b/internal/config/platforms_internal.go
@@ -1,0 +1,14 @@
+//go:build internal
+
+// Platform URL allowlist additions for internal (dev/staging) builds.
+// Compiled in only when building with `-tags internal` (see Makefile:
+// build-internal-*). Production builds exclude this file entirely, so
+// dev/staging URLs are not reachable through validation or the GUI.
+package config
+
+func init() {
+	AllowedPlatformURLs = append(AllowedPlatformURLs,
+		PlatformURL{URL: "https://platform-stage.rescale.com", Label: "Staging"},
+		PlatformURL{URL: "https://platform-dev.rescale.com", Label: "Dev"},
+	)
+}

--- a/internal/config/platforms_internal_test.go
+++ b/internal/config/platforms_internal_test.go
@@ -1,0 +1,20 @@
+//go:build internal
+
+package config
+
+import "testing"
+
+// TestInternalBuildAcceptsInternalURLs asserts the `internal` build-tag
+// appends the dev/staging URLs to the allowlist so validation accepts
+// them and the gated GUI dropdown can offer them.
+func TestInternalBuildAcceptsInternalURLs(t *testing.T) {
+	internalOnly := []string{
+		"https://platform-stage.rescale.com",
+		"https://platform-dev.rescale.com",
+	}
+	for _, u := range internalOnly {
+		if err := ValidatePlatformURL(u); err != nil {
+			t.Errorf("internal build rejected %q: %v", u, err)
+		}
+	}
+}

--- a/internal/config/platforms_production_test.go
+++ b/internal/config/platforms_production_test.go
@@ -1,0 +1,26 @@
+//go:build !internal
+
+package config
+
+import "testing"
+
+// TestProductionBuildRejectsInternalURLs guards the build-tag gate: in a
+// production build (no `internal` tag) the dev/staging URLs must NOT be
+// in the allowlist, so validation rejects them and the GUI dropdown
+// (which mirrors AllowedPlatformURLs) cannot offer them.
+func TestProductionBuildRejectsInternalURLs(t *testing.T) {
+	internalOnly := []string{
+		"https://platform-stage.rescale.com",
+		"https://platform-dev.rescale.com",
+	}
+	for _, u := range internalOnly {
+		if err := ValidatePlatformURL(u); err == nil {
+			t.Errorf("production build accepted %q — dev/staging URL leaked out of the internal build tag", u)
+		}
+	}
+	for _, p := range AllowedPlatformURLs {
+		if p.URL == "https://platform-stage.rescale.com" || p.URL == "https://platform-dev.rescale.com" {
+			t.Errorf("AllowedPlatformURLs in production build contains internal URL %q", p.URL)
+		}
+	}
+}


### PR DESCRIPTION
# Bearer auth for JWTs + dev/staging platform allowlist

## Why

We're wiring Rescale Interlink into an AI agent running on AWS Bedrock
AgentCore. The agent's job, in part, is to pull job output files from
Rescale Files into the runtime so it can reason over them. Today those
transfers happen through per-file MCP/httpx downloads driven by LLM
tool-use — one tool-call per file, serial, expensive in both wall time
and tokens. Replacing that with a single `rescale-int files download`
subprocess is a significant win: one process, adaptive parallelism,
bulk throughput. Benchmarks on a real job (278 files, 3.7 GB,
`eu.rescale.com`):

| Path | Elapsed | Throughput |
|---|---|---|
| Serial httpx (current agent pattern) | 1076.6 s | 3.44 MB/s |
| Parallel httpx (`Semaphore(8)`)      |  237.5 s | 15.58 MB/s |
| **`rescale-int files download` (adaptive)** |  **258.0 s** | **14.34 MB/s** |

~4× speedup over the serial LLM-driven path, and parity with a
hand-tuned concurrent httpx client — without the agent having to own
concurrency, retries, resume, or decryption logic. That's the pitch.

Two small Interlink changes are needed to make this work, bundled here.

## What's in this PR

### 1. Bearer scheme for JWT-shaped API keys (`internal/api/client.go`)

The agent receives a per-request Rescale JWT via HTTP header from
AgentCore. Interlink currently hardcodes `Authorization: Token <key>`,
which the API rejects when `<key>` is actually a JWT. This PR adds a
tiny helper:

```go
func authScheme(apiKey string) string {
    parts := strings.Split(apiKey, ".")
    if len(parts) == 3 && strings.HasPrefix(parts[0], "ey") {
        return "Bearer"
    }
    return "Token"
}
```

…and uses it at the single call site in `doRequest`. Legacy 40-char
hex tokens continue to flow through as `Token`; only three-segment
base64url values starting `ey…` are treated as JWTs.

New tests in `internal/api/client_test.go`:
- `TestAuthScheme_TokenForLegacyKeys` — hex keys still get `Token`
- `TestAuthScheme_BearerForJWT` — JWT-shaped keys get `Bearer`
- `TestDoRequest_AuthorizationHeader` — end-to-end via `httptest.Server`,
  both shapes

No changes to credential resolution, storage, config, or any other
code path.

### 2. Staging + dev in the platform allowlist (`internal/config/platforms.go`)

The platform allowlist is a security measure against credential
exfiltration via a malicious `api_base_url`. It currently allows six
production tenants. This PR adds two:

- `https://platform-stage.rescale.com` (Staging)
- `https://platform-dev.rescale.com` (Dev)

Needed because:
- Agent changes should land on dev/staging for iteration before pointing
  at production tenants.
- CI for agent integrations wants to run against dev fixtures.

The frontend dropdown in `SetupTab.tsx` is updated in the same commit
to preserve the existing "must stay in sync" invariant.

## Testing

- `go test ./internal/api/ -run 'Auth|DoRequest'` — passes (3 new tests, all green)
- `go test ./internal/config/ -run 'Platform'` — passes (13 existing tests, still green)
- End-to-end: `rescale-transfer-bench` agent image (two-stage Docker
  build compiling this branch with `GOFIPS140=latest`) downloaded
  3.7 GB of job output from `eu.rescale.com` under a per-request JWT,
  278/278 files, SHA-256 parity vs. the httpx reference path. Same
  image also exercised against `platform-dev.rescale.com` for the
  allowlist change.

## Known limitation — JWT expiry on long transfers

JWTs expire (typical Rescale TTL: ~30–60 min). This PR's Bearer path
is safe for the agent use case — short-lived, interactive downloads
driven by a fresh JWT handed in per invocation — but it does **not**
refresh tokens mid-transfer. A long-running batched transfer that
outlives its JWT will hit a 401 partway through.

This is out of scope for this PR but will be addressed in a follow-up
on a separate branch. Sketch: either (a) a pluggable credentials
provider the caller owns (clean, small API surface), or (b) a
pre-flight `exp` check that refuses a transfer whose estimated
duration exceeds remaining validity (cheap guard-rail, no auth
surface changes). Happy to take direction on which path you'd prefer
before I start that one.

## Not in this PR

- Refresh-token flow for long transfers (see above)
- Any change to the GUI config file format or CLI flags
- Any change to default credential resolution order
- Any change to how `rescale-cli` compat mode handles auth
