### PR TITLE
File Browser Trash Bin (#30)

### DIFF
--- a/frontend/src/components/tabs/FileBrowserTab.tsx
+++ b/frontend/src/components/tabs/FileBrowserTab.tsx
@@ -121,7 +121,11 @@ export function FileBrowserTab() {
     refreshLocal,
     refreshRemote,
     deleteRemoteItems,
+    recoverTrashItems,
+    purgeTrashItems,
   } = useFileBrowserStore()
+
+  const isTrashMode = remote.mode === 'trash'
 
   // Tab navigation for switching to Transfers after starting transfers
   const { switchToTab } = useTabNavigation()
@@ -152,6 +156,8 @@ export function FileBrowserTab() {
     frozenLocalPath: string           // Snapshot at click time to avoid stale navigation
   } | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState<wailsapp.FileItemDTO[] | null>(null)
+  const [recoverConfirm, setRecoverConfirm] = useState<wailsapp.FileItemDTO[] | null>(null)
+  const [purgeConfirm, setPurgeConfirm] = useState<wailsapp.FileItemDTO[] | null>(null)
 
   const [errorDialog, setErrorDialog] = useState<{ title: string; message: string } | null>(null)
   const [folderConflict, setFolderConflict] = useState<{
@@ -644,6 +650,47 @@ export function FileBrowserTab() {
     }
   }, [deleteConfirm, deleteRemoteItems])
 
+  // Trash: recover / purge handlers
+  const handleRecover = useCallback(() => {
+    const selected = getRemoteSelectedItems()
+    if (selected.length === 0) return
+    setRecoverConfirm(selected)
+  }, [getRemoteSelectedItems])
+
+  const handlePurge = useCallback(() => {
+    const selected = getRemoteSelectedItems()
+    if (selected.length === 0) return
+    setPurgeConfirm(selected)
+  }, [getRemoteSelectedItems])
+
+  const confirmRecover = useCallback(async () => {
+    if (!recoverConfirm) return
+    const items = recoverConfirm
+    setRecoverConfirm(null)
+    setStatus(`Recovering ${items.length} item(s)...`)
+    const result = await recoverTrashItems(items)
+    if (result.error) {
+      setErrorDialog({ title: 'Recover Failed', message: result.error })
+      setStatus('Recover failed')
+    } else {
+      setStatus(`Recovered ${result.recovered} item(s) to their original location`)
+    }
+  }, [recoverConfirm, recoverTrashItems])
+
+  const confirmPurge = useCallback(async () => {
+    if (!purgeConfirm) return
+    const items = purgeConfirm
+    setPurgeConfirm(null)
+    setStatus(`Permanently deleting ${items.length} item(s)...`)
+    const result = await purgeTrashItems(items)
+    if (result.error) {
+      setErrorDialog({ title: 'Delete Failed', message: result.error })
+      setStatus('Permanent delete failed')
+    } else {
+      setStatus(`Permanently deleted ${result.deleted} item(s)`)
+    }
+  }, [purgeConfirm, purgeTrashItems])
+
   // Upload button text
   const uploadButtonText = useMemo(() => {
     if (!uploadState.allowed && uploadState.reason) {
@@ -710,10 +757,10 @@ export function FileBrowserTab() {
             <div className="flex items-center gap-2">
               <button
                 onClick={handleDownload}
-                disabled={remoteSelectedCount === 0 || isDownloading}
-                title="Download selected files to local"
+                disabled={remoteSelectedCount === 0 || isDownloading || isTrashMode}
+                title={isTrashMode ? 'Not available in Trash — recover items first' : 'Download selected files to local'}
                 className={`flex items-center gap-1 px-3 py-1 text-sm rounded ${
-                  remoteSelectedCount > 0 && !isDownloading
+                  remoteSelectedCount > 0 && !isDownloading && !isTrashMode
                     ? 'bg-blue-500 text-white hover:bg-blue-600'
                     : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
                 }`}
@@ -722,25 +769,27 @@ export function FileBrowserTab() {
                 <ArrowDownTrayIcon className="w-4 h-4" />
                 {remoteSelectedCount > 0 ? `Download ${remoteSelectedCount}` : 'Download'}
               </button>
-              <button
-                onClick={handleDelete}
-                disabled={remoteSelectedCount === 0 || isDeleting}
-                title="Delete selected items from Rescale"
-                className={`flex items-center gap-1 px-3 py-1 text-sm rounded ${
-                  remoteSelectedCount > 0 && !isDeleting
-                    ? 'bg-red-500 text-white hover:bg-red-600'
-                    : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
-                }`}
-              >
-                <TrashIcon className="w-4 h-4" />
-                Delete
-              </button>
+              {!isTrashMode && (
+                <button
+                  onClick={handleDelete}
+                  disabled={remoteSelectedCount === 0 || isDeleting}
+                  title="Delete selected items from Rescale"
+                  className={`flex items-center gap-1 px-3 py-1 text-sm rounded ${
+                    remoteSelectedCount > 0 && !isDeleting
+                      ? 'bg-red-500 text-white hover:bg-red-600'
+                      : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+                  }`}
+                >
+                  <TrashIcon className="w-4 h-4" />
+                  Delete
+                </button>
+              )}
             </div>
           </div>
 
           {/* Remote browser */}
           <div className="flex-1 overflow-hidden">
-            <RemoteBrowser />
+            <RemoteBrowser onTrashRecover={handleRecover} onTrashPurge={handlePurge} />
           </div>
         </div>
       </div>
@@ -807,6 +856,26 @@ export function FileBrowserTab() {
         isDanger
         onConfirm={confirmDelete}
         onCancel={() => setDeleteConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={recoverConfirm !== null}
+        title="Recover from Trash"
+        message={`Recover ${recoverConfirm?.length ?? 0} item(s) to their original location?`}
+        confirmText="Recover"
+        onConfirm={confirmRecover}
+        onCancel={() => setRecoverConfirm(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={purgeConfirm !== null}
+        title="Delete Permanently"
+        message={`Permanently delete ${purgeConfirm?.length ?? 0} item(s) from your trash?`}
+        confirmText="Delete Permanently"
+        isDanger
+        warning="This action is permanent and cannot be undone."
+        onConfirm={confirmPurge}
+        onCancel={() => setPurgeConfirm(null)}
       />
 
       <ConfirmDialog

--- a/frontend/src/components/widgets/RemoteBrowser.tsx
+++ b/frontend/src/components/widgets/RemoteBrowser.tsx
@@ -2,13 +2,20 @@ import { useEffect, useCallback, useState } from 'react'
 import {
   ArrowLeftIcon,
   ArrowPathIcon,
+  ArrowUturnLeftIcon,
   FolderPlusIcon,
   ChevronRightIcon,
+  TrashIcon,
 } from '@heroicons/react/24/outline'
 import { useFileBrowserStore, BrowseMode } from '../../stores'
 import { FileList } from './FileList'
 
-export function RemoteBrowser() {
+interface RemoteBrowserProps {
+  onTrashRecover?: () => void
+  onTrashPurge?: () => void
+}
+
+export function RemoteBrowser({ onTrashRecover, onTrashPurge }: RemoteBrowserProps = {}) {
   const {
     remote: {
       mode,
@@ -39,6 +46,9 @@ export function RemoteBrowser() {
     goToPreviousRemotePage,
   } = useFileBrowserStore()
 
+  const isTrash = mode === 'trash'
+  const hasSelection = selection.selectedIds.size > 0
+
   const [showNewFolderDialog, setShowNewFolderDialog] = useState(false)
   const [newFolderName, setNewFolderName] = useState('')
   const [isCreatingFolder, setIsCreatingFolder] = useState(false)
@@ -57,12 +67,15 @@ export function RemoteBrowser() {
     }
   }, [mode, setRemoteMode])
 
-  // Handle folder open from FileList
+  // Handle folder open from FileList.
+  // In trash mode, folder-like entries are non-navigable — they represent
+  // whole trashed job outputs and are treated as opaque items.
   const handleFolderOpen = useCallback((item: { id: string; name: string; isFolder: boolean }) => {
+    if (isTrash) return
     if (item.isFolder && item.id) {
       navigateRemoteTo(item.id, item.name)
     }
-  }, [navigateRemoteTo])
+  }, [isTrash, navigateRemoteTo])
 
   // Handle selection change
   const handleSelectionChange = useCallback((ids: Set<string>, lastId: string | null) => {
@@ -105,17 +118,18 @@ export function RemoteBrowser() {
 
         {/* Mode toggle */}
         <div className="flex items-center bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded overflow-hidden">
-          {(['library', 'jobs', 'legacy'] as BrowseMode[]).map((m) => (
+          {(['library', 'jobs', 'legacy', 'trash'] as BrowseMode[]).map((m) => (
             <button
               key={m}
               onClick={() => handleModeChange(m)}
-              className={`px-3 py-1 text-xs font-medium transition-colors ${
+              className={`px-3 py-1 text-xs font-medium transition-colors flex items-center gap-1 ${
                 mode === m
                   ? 'bg-blue-500 text-white'
                   : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
               }`}
             >
-              {m === 'library' ? 'My Library' : m === 'jobs' ? 'My Jobs' : 'Legacy'}
+              {m === 'trash' && <TrashIcon className="w-3.5 h-3.5" />}
+              {m === 'library' ? 'My Library' : m === 'jobs' ? 'My Jobs' : m === 'legacy' ? 'Legacy' : 'Trash'}
             </button>
           ))}
         </div>
@@ -124,7 +138,7 @@ export function RemoteBrowser() {
         <div className="flex-1" />
 
         {/* New folder button (only in My Library) */}
-        {canCreateFolder && (
+        {canCreateFolder && !isTrash && (
           <button
             onClick={() => setShowNewFolderDialog(true)}
             className="p-1.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
@@ -143,6 +157,38 @@ export function RemoteBrowser() {
         >
           <ArrowPathIcon className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
         </button>
+
+        {/* Trash-only actions */}
+        {isTrash && (
+          <>
+            <button
+              onClick={onTrashRecover}
+              disabled={!hasSelection || !onTrashRecover}
+              title="Recover selected items to their original location"
+              className={`flex items-center gap-1 px-3 py-1 text-xs rounded ${
+                hasSelection && onTrashRecover
+                  ? 'bg-blue-500 text-white hover:bg-blue-600'
+                  : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              <ArrowUturnLeftIcon className="w-3.5 h-3.5" />
+              Recover
+            </button>
+            <button
+              onClick={onTrashPurge}
+              disabled={!hasSelection || !onTrashPurge}
+              title="Permanently delete selected items — cannot be undone"
+              className={`flex items-center gap-1 px-3 py-1 text-xs rounded ${
+                hasSelection && onTrashPurge
+                  ? 'bg-red-500 text-white hover:bg-red-600'
+                  : 'bg-gray-300 dark:bg-gray-600 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              <TrashIcon className="w-3.5 h-3.5" />
+              Delete Permanently
+            </button>
+          </>
+        )}
       </div>
 
       {/* Breadcrumb */}
@@ -184,6 +230,8 @@ export function RemoteBrowser() {
               ? 'Your library is empty'
               : mode === 'jobs'
               ? 'No job files found'
+              : mode === 'trash'
+              ? 'Trash is empty'
               : 'No files found'
           }
           loadingMessage={

--- a/frontend/src/stores/fileBrowserStore.ts
+++ b/frontend/src/stores/fileBrowserStore.ts
@@ -5,7 +5,7 @@ import { wailsapp } from '../../wailsjs/go/models'
 import { EVENT_NAMES } from '../types/events'
 
 // Browse mode for remote browser (matching Go BrowseMode)
-export type BrowseMode = 'library' | 'jobs' | 'legacy'
+export type BrowseMode = 'library' | 'jobs' | 'legacy' | 'trash'
 
 const PAGE_CACHE_TTL = 5 * 60 * 1000  // 5 minutes
 const MAX_CACHED_PAGES = 10           // Limit memory usage
@@ -97,6 +97,7 @@ interface FileBrowserStore {
   setRemoteMode: (mode: BrowseMode) => void
   loadRemoteFolder: (folderId?: string, folderName?: string) => Promise<void>
   loadRemoteLegacy: () => Promise<void>
+  loadRemoteTrash: () => Promise<void>
   navigateRemoteTo: (folderId: string, folderName: string) => void
   navigateRemoteToBreadcrumb: (index: number) => void
   goRemoteBack: () => void
@@ -105,6 +106,8 @@ interface FileBrowserStore {
   clearRemoteSelection: () => void
   createRemoteFolder: (name: string) => Promise<string | null>
   deleteRemoteItems: (items: wailsapp.FileItemDTO[]) => Promise<{ deleted: number; failed: number }>
+  recoverTrashItems: (items: wailsapp.FileItemDTO[]) => Promise<{ recovered: number; failed: number; error?: string }>
+  purgeTrashItems: (items: wailsapp.FileItemDTO[]) => Promise<{ deleted: number; failed: number; error?: string }>
   setRemoteItemsPerPage: (size: number) => void       // Change page size, reload page 0
   goToNextRemotePage: () => Promise<void>             // Navigate to next page (replaces items)
   goToPreviousRemotePage: () => Promise<void>         // Navigate to previous page (from cache)
@@ -320,6 +323,8 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
       const mode = get().remote.mode
       if (mode === 'legacy') {
         await get().loadRemoteLegacy()
+      } else if (mode === 'trash') {
+        await get().loadRemoteTrash()
       } else {
         const folderId = mode === 'library' ? myLibraryId : myJobsId
         const folderName = mode === 'library' ? 'My Library' : 'My Jobs'
@@ -359,6 +364,8 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
 
     if (mode === 'legacy') {
       get().loadRemoteLegacy()
+    } else if (mode === 'trash') {
+      get().loadRemoteTrash()
     } else {
       const folderId = mode === 'library' ? myLibraryId : myJobsId
       const folderName = mode === 'library' ? 'My Library' : 'My Jobs'
@@ -577,6 +584,91 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
       }))
     }
   },
+  loadRemoteTrash: async () => {
+    const state = get().remote
+    const currentPage = state.currentPage
+    const itemsPerPage = state.itemsPerPage
+    const cursor = state.pageCursors[currentPage] ?? ''
+
+    const cachedPage = state.pageCache.get(currentPage)
+    if (cachedPage && (Date.now() - cachedPage.timestamp) < PAGE_CACHE_TTL) {
+      set(state => ({
+        remote: {
+          ...state.remote,
+          items: cachedPage.items,
+          hasMore: cachedPage.hasMore,
+          nextCursor: cachedPage.nextCursor,
+          isLoading: false,
+          error: null,
+        }
+      }))
+      return
+    }
+
+    const myGen = get().remote.navGeneration
+
+    set(state => ({
+      remote: { ...state.remote, isLoading: true, error: null }
+    }))
+
+    try {
+      const contents = await App.ListRemoteTrash(cursor, itemsPerPage)
+
+      if (get().remote.navGeneration !== myGen) return
+
+      const newPageCursors = [...state.pageCursors]
+      if (contents.hasMore && contents.nextCursor) {
+        newPageCursors[currentPage + 1] = contents.nextCursor
+      }
+
+      const newCache = new Map(state.pageCache)
+      newCache.set(currentPage, {
+        items: contents.items,
+        hasMore: contents.hasMore,
+        nextCursor: contents.nextCursor ?? '',
+        timestamp: Date.now(),
+      })
+      if (newCache.size > MAX_CACHED_PAGES) {
+        const oldestKey = newCache.keys().next().value
+        if (oldestKey !== undefined) {
+          newCache.delete(oldestKey)
+        }
+      }
+
+      let knownTotalPages = state.knownTotalPages
+      if (contents.hasMore && currentPage + 1 >= knownTotalPages) {
+        knownTotalPages = currentPage + 2
+      } else if (!contents.hasMore) {
+        knownTotalPages = currentPage + 1
+      }
+
+      set(state => ({
+        remote: {
+          ...state.remote,
+          currentFolderId: 'trash',
+          items: contents.items,
+          isLoading: false,
+          error: contents.warning || null,
+          hasMore: contents.hasMore,
+          nextCursor: contents.nextCursor ?? '',
+          breadcrumb: [{ id: 'trash', name: 'Trash' }],
+          pageCursors: newPageCursors,
+          knownTotalPages,
+          pageCache: newCache,
+        }
+      }))
+    } catch (error) {
+      if (get().remote.navGeneration !== myGen) return
+      set(state => ({
+        remote: {
+          ...state.remote,
+          isLoading: false,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }))
+    }
+  },
+
   setRemoteItemsPerPage: (size: number) => {
     // Clamp to reasonable range
     const clampedSize = Math.max(10, Math.min(200, size))
@@ -597,6 +689,8 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
     const { mode } = get().remote
     if (mode === 'legacy') {
       get().loadRemoteLegacy()
+    } else if (mode === 'trash') {
+      get().loadRemoteTrash()
     } else {
       get().loadRemoteFolder()
     }
@@ -618,6 +712,8 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
     // Load the next page
     if (mode === 'legacy') {
       await get().loadRemoteLegacy()
+    } else if (mode === 'trash') {
+      await get().loadRemoteTrash()
     } else {
       await get().loadRemoteFolder()
     }
@@ -635,6 +731,8 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
     // Load the previous page (will use cache if available)
     if (mode === 'legacy') {
       await get().loadRemoteLegacy()
+    } else if (mode === 'trash') {
+      await get().loadRemoteTrash()
     } else {
       await get().loadRemoteFolder()
     }
@@ -703,6 +801,8 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
 
     if (mode === 'legacy') {
       get().loadRemoteLegacy()
+    } else if (mode === 'trash') {
+      get().loadRemoteTrash()
     } else {
       get().loadRemoteFolder()
     }
@@ -758,6 +858,34 @@ export const useFileBrowserStore = create<FileBrowserStore>((set, get) => ({
     } catch (error) {
       console.error('Failed to delete items:', error)
       return { deleted: 0, failed: items.length }
+    }
+  },
+
+  recoverTrashItems: async (items: wailsapp.FileItemDTO[]) => {
+    try {
+      const result = await App.RecoverTrashItems(items)
+      if (result.deleted > 0) {
+        get().refreshRemote()
+        get().clearRemoteSelection()
+      }
+      return { recovered: result.deleted, failed: result.failed, error: result.error }
+    } catch (error) {
+      console.error('Failed to recover items:', error)
+      return { recovered: 0, failed: items.length, error: error instanceof Error ? error.message : String(error) }
+    }
+  },
+
+  purgeTrashItems: async (items: wailsapp.FileItemDTO[]) => {
+    try {
+      const result = await App.PurgeTrashItems(items)
+      if (result.deleted > 0) {
+        get().refreshRemote()
+        get().clearRemoteSelection()
+      }
+      return { deleted: result.deleted, failed: result.failed, error: result.error }
+    } catch (error) {
+      console.error('Failed to purge items:', error)
+      return { deleted: 0, failed: items.length, error: error instanceof Error ? error.message : String(error) }
     }
   },
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -666,6 +666,7 @@ export namespace wailsapp {
 	    modTime: string;
 	    path?: string;
 	    parentId?: string;
+	    symlinkId?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new FileItemDTO(source);
@@ -680,6 +681,7 @@ export namespace wailsapp {
 	        this.modTime = source["modTime"];
 	        this.path = source["path"];
 	        this.parentId = source["parentId"];
+	        this.symlinkId = source["symlinkId"];
 	    }
 	}
 	export class FileLoggingSettingsDTO {

--- a/frontend/wailsjs/go/wailsapp/App.d.ts
+++ b/frontend/wailsjs/go/wailsapp/App.d.ts
@@ -106,6 +106,8 @@ export function ListRemoteFolderPage(arg1:string,arg2:string,arg3:number):Promis
 
 export function ListRemoteLegacy(arg1:string,arg2:number):Promise<wailsapp.FolderContentsDTO>;
 
+export function ListRemoteTrash(arg1:string,arg2:number):Promise<wailsapp.FolderContentsDTO>;
+
 export function ListSavedTemplates():Promise<Array<wailsapp.TemplateInfoDTO>>;
 
 export function LoadConfigFromPath(arg1:string):Promise<void>;
@@ -125,6 +127,10 @@ export function OpenLogsDirectory():Promise<void>;
 export function PauseDaemon():Promise<void>;
 
 export function PreviewCommandPatterns(arg1:string,arg2:Array<string>):Promise<Array<wailsapp.CommandPreviewDTO>>;
+
+export function PurgeTrashItems(arg1:Array<wailsapp.FileItemDTO>):Promise<wailsapp.DeleteResultDTO>;
+
+export function RecoverTrashItems(arg1:Array<wailsapp.FileItemDTO>):Promise<wailsapp.DeleteResultDTO>;
 
 export function ReloadDaemonConfig():Promise<wailsapp.ReloadConfigResultDTO>;
 

--- a/frontend/wailsjs/go/wailsapp/App.js
+++ b/frontend/wailsjs/go/wailsapp/App.js
@@ -210,6 +210,10 @@ export function ListRemoteLegacy(arg1, arg2) {
   return window['go']['wailsapp']['App']['ListRemoteLegacy'](arg1, arg2);
 }
 
+export function ListRemoteTrash(arg1, arg2) {
+  return window['go']['wailsapp']['App']['ListRemoteTrash'](arg1, arg2);
+}
+
 export function ListSavedTemplates() {
   return window['go']['wailsapp']['App']['ListSavedTemplates']();
 }
@@ -248,6 +252,14 @@ export function PauseDaemon() {
 
 export function PreviewCommandPatterns(arg1, arg2) {
   return window['go']['wailsapp']['App']['PreviewCommandPatterns'](arg1, arg2);
+}
+
+export function PurgeTrashItems(arg1) {
+  return window['go']['wailsapp']['App']['PurgeTrashItems'](arg1);
+}
+
+export function RecoverTrashItems(arg1) {
+  return window['go']['wailsapp']['App']['RecoverTrashItems'](arg1);
 }
 
 export function ReloadDaemonConfig() {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1031,6 +1031,10 @@ type FileInfo struct {
 	DecryptedSize int64
 	DateUploaded  time.Time
 
+	// SymlinkID is the top-level filesymlink id from trash listings (entry.id).
+	// Empty for non-trash listings.
+	SymlinkID string
+
 	// Full metadata fields — when populated, downloads skip GetFileInfo()
 	EncodedEncryptionKey string
 	IV                   string
@@ -1190,15 +1194,8 @@ func parseFileChecksums(itemData map[string]interface{}) []models.FileChecksum {
 // Pass pageURL="" for the first page, or use NextURL/PrevURL from previous response.
 // pageSize: pass 0 for API default, or specify items per page.
 func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL string, pageSize int) (*FolderContents, error) {
-	contents := &FolderContents{
-		Folders: make([]FolderInfo, 0),
-		Files:   make([]FileInfo, 0),
-	}
-
-	// Determine URL for this request
 	url := pageURL
 	if url == "" {
-		// Include page_size in first page request if specified
 		if pageSize > 0 {
 			url = fmt.Sprintf("/api/v3/folders/%s/contents/?page_size=%d", folderID, pageSize)
 		} else {
@@ -1215,6 +1212,18 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 			u.RawQuery = q.Encode()
 			url = u.String()
 		}
+	}
+
+	return c.fetchFolderContentsPage(ctx, url)
+}
+
+// fetchFolderContentsPage issues a GET to the given URL and parses the
+// standard folder-contents response shape (results / next / previous).
+// Shared by folder listings and trash-bin listings.
+func (c *Client) fetchFolderContentsPage(ctx context.Context, url string) (*FolderContents, error) {
+	contents := &FolderContents{
+		Folders: make([]FolderInfo, 0),
+		Files:   make([]FileInfo, 0),
 	}
 
 	resp, err := c.doRequest(ctx, "GET", url, nil)
@@ -1240,7 +1249,6 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 	}
 	resp.Body.Close()
 
-	// Process items from this page
 	for _, entry := range result.Results {
 		itemType := getStringField(entry, "type", "folderContents")
 		itemData, ok := entry["item"].(map[string]interface{})
@@ -1255,7 +1263,6 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 						ID:   id,
 						Name: name,
 					}
-					// Parse date: try dateUploaded (library), dateInserted (jobs), dateCreated
 					if dateStr, ok := itemData["dateUploaded"].(string); ok {
 						if t, err := time.Parse(time.RFC3339, dateStr); err == nil {
 							folder.DateUploaded = t
@@ -1272,12 +1279,10 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 					contents.Folders = append(contents.Folders, folder)
 				}
 			}
-		} else if itemType == "file" {
+		} else if itemType == "file" || itemType == "filesymlink" {
 			id := getStringField(itemData, "id", "file")
 			name := getStringField(itemData, "name", "file")
 			size := int64(0)
-			// JSON numbers are float64 by default, which can lose precision for files > 2^53 bytes.
-			// Also handle string and json.Number representations for robustness.
 			if rawSize, ok := itemData["decryptedSize"]; ok {
 				switch v := rawSize.(type) {
 				case float64:
@@ -1296,8 +1301,8 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 				ID:            id,
 				Name:          name,
 				DecryptedSize: size,
+				SymlinkID:     id,
 			}
-			// Parse full metadata to eliminate per-file GetFileInfo() calls
 			file.EncodedEncryptionKey, _ = itemData["encodedEncryptionKey"].(string)
 			file.IV, _ = itemData["iv"].(string)
 			file.Owner, _ = itemData["owner"].(string)
@@ -1306,7 +1311,6 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 			file.Storage = parseStorage(itemData)
 			file.FileChecksums = parseFileChecksums(itemData)
 
-			// Parse date: try dateUploaded (library), dateInserted (jobs), dateCreated
 			if dateStr, ok := itemData["dateUploaded"].(string); ok {
 				if t, err := time.Parse(time.RFC3339, dateStr); err == nil {
 					file.DateUploaded = t
@@ -1324,7 +1328,6 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 		}
 	}
 
-	// Set pagination info
 	contents.PageSize = len(result.Results)
 	if result.Next != nil && *result.Next != "" {
 		contents.NextURL = extractAPIPath(*result.Next)
@@ -1335,6 +1338,71 @@ func (c *Client) ListFolderContentsPage(ctx context.Context, folderID, pageURL s
 	}
 
 	return contents, nil
+}
+
+// ListTrashBinPage fetches a page of the user's trash bin.
+// Trash contains both files (identified by entry.id / SymlinkID) and
+// folder-like items (job outputs, identified by item.id / FolderInfo.ID).
+// Pass pageURL="" for the first page; use NextURL from the previous response for subsequent pages.
+func (c *Client) ListTrashBinPage(ctx context.Context, pageURL string, pageSize int) (*FolderContents, error) {
+	url := pageURL
+	if url == "" {
+		if pageSize > 0 {
+			url = fmt.Sprintf("/api/v3/users/me/folders/trash-bin/?page_size=%d", pageSize)
+		} else {
+			url = "/api/v3/users/me/folders/trash-bin/"
+		}
+	}
+
+	if pageSize > 0 && pageURL != "" {
+		if u, err := neturl.Parse(url); err == nil {
+			q := u.Query()
+			q.Set("page_size", strconv.Itoa(pageSize))
+			u.RawQuery = q.Encode()
+			url = u.String()
+		}
+	}
+
+	return c.fetchFolderContentsPage(ctx, url)
+}
+
+// PostTrashBinAction POSTs a bulk recover or permanent-delete to the trash-bin endpoint.
+// action must be "recover" or "delete". Both take the same payload:
+//
+//	{"folderIds": [...], "filesymlink_ids": [...]}
+//
+// The endpoint returns 201 Created on success and is all-or-nothing.
+func (c *Client) PostTrashBinAction(ctx context.Context, action string, fileSymlinkIDs []string, folderIDs []string) error {
+	if action != "recover" && action != "delete" {
+		return fmt.Errorf("invalid trash-bin action %q (must be \"recover\" or \"delete\")", action)
+	}
+
+	// Ensure JSON encodes empty lists as [] rather than null.
+	if fileSymlinkIDs == nil {
+		fileSymlinkIDs = []string{}
+	}
+	if folderIDs == nil {
+		folderIDs = []string{}
+	}
+
+	body := map[string]interface{}{
+		"filesymlink_ids": fileSymlinkIDs,
+		"folderIds":       folderIDs,
+	}
+
+	url := fmt.Sprintf("/api/v3/users/me/folders/trash-bin/%s/", action)
+	resp, err := c.doRequest(ctx, "POST", url, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != nethttp.StatusCreated && resp.StatusCode != nethttp.StatusOK && resp.StatusCode != nethttp.StatusNoContent {
+		respBody := readResponseBody(resp.Body)
+		return fmt.Errorf("trash-bin %s failed with status %d: %s", action, resp.StatusCode, respBody)
+	}
+
+	return nil
 }
 
 // extractAPIPath extracts the API path from a full URL or returns the path as-is.

--- a/internal/services/file_service.go
+++ b/internal/services/file_service.go
@@ -439,6 +439,98 @@ func (fs *FileService) GetMyJobsFolderID(ctx context.Context) (string, error) {
 	return roots.MyJobs, nil
 }
 
+// ListTrashBinPage returns a single page of trash-bin contents.
+// Files in the result have SymlinkID populated (needed for recover/purge).
+// Folder-like items use FileItem.ID (which is the folder id).
+func (fs *FileService) ListTrashBinPage(ctx context.Context, cursor string, pageSize int) (*FolderContents, error) {
+	fs.mu.RLock()
+	apiClient := fs.apiClient
+	fs.mu.RUnlock()
+
+	if apiClient == nil {
+		return nil, fmt.Errorf("API client not configured")
+	}
+
+	contents, err := apiClient.ListTrashBinPage(ctx, cursor, pageSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list trash: %w", err)
+	}
+
+	items := make([]FileItem, 0, len(contents.Folders)+len(contents.Files))
+
+	for _, f := range contents.Folders {
+		items = append(items, FileItem{
+			ID:       f.ID,
+			Name:     f.Name,
+			IsFolder: true,
+			ModTime:  f.DateUploaded,
+		})
+	}
+
+	for _, f := range contents.Files {
+		items = append(items, FileItem{
+			ID:        f.ID,
+			Name:      f.Name,
+			IsFolder:  false,
+			Size:      f.DecryptedSize,
+			ModTime:   f.DateUploaded,
+			SymlinkID: f.SymlinkID,
+		})
+	}
+
+	return &FolderContents{
+		FolderID:   "trash",
+		FolderPath: "Trash",
+		Items:      items,
+		HasMore:    contents.HasMore,
+		NextCursor: contents.NextURL,
+	}, nil
+}
+
+// RecoverTrashItems restores a mix of trashed files and folders to their
+// original locations via a single bulk POST. The endpoint is all-or-nothing.
+func (fs *FileService) RecoverTrashItems(ctx context.Context, items []FileItem) (recovered int, failed int, err error) {
+	return fs.postTrashAction(ctx, "recover", items)
+}
+
+// PurgeTrashItems permanently deletes a mix of trashed files and folders via
+// a single bulk POST. This is irreversible. The endpoint is all-or-nothing.
+func (fs *FileService) PurgeTrashItems(ctx context.Context, items []FileItem) (deleted int, failed int, err error) {
+	return fs.postTrashAction(ctx, "delete", items)
+}
+
+func (fs *FileService) postTrashAction(ctx context.Context, action string, items []FileItem) (int, int, error) {
+	fs.mu.RLock()
+	apiClient := fs.apiClient
+	fs.mu.RUnlock()
+
+	if apiClient == nil {
+		return 0, len(items), fmt.Errorf("API client not configured")
+	}
+	if len(items) == 0 {
+		return 0, 0, nil
+	}
+
+	fileSymlinkIDs := make([]string, 0, len(items))
+	folderIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		if item.IsFolder {
+			folderIDs = append(folderIDs, item.ID)
+		} else {
+			if item.SymlinkID == "" {
+				return 0, len(items), fmt.Errorf("trash file item %q is missing SymlinkID", item.Name)
+			}
+			fileSymlinkIDs = append(fileSymlinkIDs, item.SymlinkID)
+		}
+	}
+
+	if err := apiClient.PostTrashBinAction(ctx, action, fileSymlinkIDs, folderIDs); err != nil {
+		fs.logger.Error().Err(err).Str("action", action).Int("count", len(items)).Msg("Trash bulk action failed")
+		return 0, len(items), err
+	}
+	return len(items), 0, nil
+}
+
 // ListFolderPage returns a single page of folder contents with pagination support.
 // Pass empty cursor for first page, or use NextCursor from previous response.
 // Pass pageSize=0 for API default.

--- a/internal/services/types.go
+++ b/internal/services/types.go
@@ -200,6 +200,10 @@ type FileItem struct {
 
 	// ParentID is the parent folder ID (for remote files)
 	ParentID string
+
+	// SymlinkID is the filesymlink id for trash-bin entries (files only).
+	// Populated only by trash listings; empty otherwise.
+	SymlinkID string
 }
 
 // BrowseMode indicates the remote browsing context.
@@ -209,6 +213,7 @@ const (
 	BrowseModeLibrary BrowseMode = "library" // My Library (folders)
 	BrowseModeJobs    BrowseMode = "jobs"    // My Jobs
 	BrowseModeLegacy  BrowseMode = "legacy"  // Legacy flat file list
+	BrowseModeTrash   BrowseMode = "trash"   // Trash bin
 )
 
 // FolderContents represents the contents of a folder.

--- a/internal/wailsapp/file_bindings.go
+++ b/internal/wailsapp/file_bindings.go
@@ -60,13 +60,14 @@ func translateAPIError(err error) string {
 
 // FileItemDTO is the JSON-safe version of services.FileItem.
 type FileItemDTO struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	IsFolder bool   `json:"isFolder"`
-	Size     int64  `json:"size"`
-	ModTime  string `json:"modTime"`
-	Path     string `json:"path,omitempty"`
-	ParentID string `json:"parentId,omitempty"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	IsFolder  bool   `json:"isFolder"`
+	Size      int64  `json:"size"`
+	ModTime   string `json:"modTime"`
+	Path      string `json:"path,omitempty"`
+	ParentID  string `json:"parentId,omitempty"`
+	SymlinkID string `json:"symlinkId,omitempty"`
 }
 
 // FolderContentsDTO is the JSON-safe version of services.FolderContents.
@@ -304,6 +305,84 @@ func (a *App) ListRemoteLegacy(cursor string, pageSize int) FolderContentsDTO {
 	return folderContentsToDTO(contents)
 }
 
+// ListRemoteTrash returns a single page of the user's trash bin.
+// Items include both files (with SymlinkID populated) and folder-like entries.
+// Pass pageSize=0 for API default.
+func (a *App) ListRemoteTrash(cursor string, pageSize int) FolderContentsDTO {
+	if a.engine == nil {
+		return FolderContentsDTO{}
+	}
+
+	fs := a.engine.FileService()
+	if fs == nil {
+		return FolderContentsDTO{}
+	}
+
+	ctx := context.Background()
+	contents, err := fs.ListTrashBinPage(ctx, cursor, pageSize)
+	if err != nil {
+		return FolderContentsDTO{
+			FolderID:   "trash",
+			FolderPath: "Trash",
+			Items:      []FileItemDTO{},
+			Warning:    translateAPIError(err),
+		}
+	}
+
+	dto := folderContentsToDTO(contents)
+	dto.FolderID = "trash"
+	return dto
+}
+
+// RecoverTrashItems restores selected trash items to their original locations.
+func (a *App) RecoverTrashItems(items []FileItemDTO) DeleteResultDTO {
+	return a.postTrashItems(items, true)
+}
+
+// PurgeTrashItems permanently deletes selected trash items. Irreversible.
+func (a *App) PurgeTrashItems(items []FileItemDTO) DeleteResultDTO {
+	return a.postTrashItems(items, false)
+}
+
+func (a *App) postTrashItems(items []FileItemDTO, recover bool) DeleteResultDTO {
+	if a.engine == nil {
+		return DeleteResultDTO{Error: ErrNoEngine.Error(), Failed: len(items)}
+	}
+
+	fs := a.engine.FileService()
+	if fs == nil {
+		return DeleteResultDTO{Error: ErrNoFileService.Error(), Failed: len(items)}
+	}
+
+	serviceItems := make([]services.FileItem, len(items))
+	for i, item := range items {
+		serviceItems[i] = services.FileItem{
+			ID:        item.ID,
+			Name:      item.Name,
+			IsFolder:  item.IsFolder,
+			SymlinkID: item.SymlinkID,
+		}
+	}
+
+	ctx := context.Background()
+	var count, failed int
+	var err error
+	if recover {
+		count, failed, err = fs.RecoverTrashItems(ctx, serviceItems)
+	} else {
+		count, failed, err = fs.PurgeTrashItems(ctx, serviceItems)
+	}
+
+	result := DeleteResultDTO{
+		Deleted: count,
+		Failed:  failed,
+	}
+	if err != nil {
+		result.Error = translateAPIError(err)
+	}
+	return result
+}
+
 // ValidateRemoteFolder checks that a remote folder exists and is accessible.
 // Lightweight preflight check — fetches a single item from the first page.
 // Does NOT use FolderCache.Get() (which fetches all pages).
@@ -427,13 +506,14 @@ func folderContentsToDTO(contents *services.FolderContents) FolderContentsDTO {
 	items := make([]FileItemDTO, len(contents.Items))
 	for i, item := range contents.Items {
 		items[i] = FileItemDTO{
-			ID:       item.ID,
-			Name:     item.Name,
-			IsFolder: item.IsFolder,
-			Size:     item.Size,
-			ModTime:  item.ModTime.Format(time.RFC3339),
-			Path:     item.Path,
-			ParentID: item.ParentID,
+			ID:        item.ID,
+			Name:      item.Name,
+			IsFolder:  item.IsFolder,
+			Size:      item.Size,
+			ModTime:   item.ModTime.Format(time.RFC3339),
+			Path:      item.Path,
+			ParentID:  item.ParentID,
+			SymlinkID: item.SymlinkID,
 		}
 	}
 


### PR DESCRIPTION
## Summary
- New **Trash** view in the File Browser alongside My Library / My Jobs / Legacy
- Bulk **Recover** (blue) and **Delete Permanently** (red) actions via `/api/v3/users/me/folders/trash-bin/{recover,delete}/` — single request, all-or-nothing per 201 semantics
- Mirrors the Rescale web UI behavior: files (filesymlink) + folder-like job-output entries coexist, both recoverable or purgeable in one mixed selection

## Implementation notes
- **Go**: `ListTrashBinPage` + shared `PostTrashBinAction("recover"|"delete", ...)`; parser factored into `fetchFolderContentsPage` and extended to accept `filesymlink` items, populating `SymlinkID` from `item.id`
- **Services**: `RecoverTrashItems` / `PurgeTrashItems` split payload into `filesymlink_ids` (files) and `folderIds` (folders)
- **Store**: adds `'trash'` `BrowseMode`; `loadRemoteTrash` uses the existing cursor-paged pattern; recover/purge refresh + clear selection
- **UI**: Trash pill with trash icon; in trash mode, folders are non-navigable, new-folder is hidden, download is disabled, and delete is replaced by Recover / Delete Permanently (latter with strong warning dialog)

## Out of scope (follow-ups pending feature-requester feedback)
- Trash pill vs separate icon button placement
- Whether Recover-confirm dialog is friction worth removing
- ID / Tags columns
- "Empty All" shortcut, trash count badge, navigating into trashed folders

## Test plan
- [x] `go build ./...` passes
- [x] `cd frontend && npm run build` passes
- [x] Trash list renders both file-style and folder-style entries with sizes/dates matching web UI
- [x] Multi-select (single, Ctrl/Cmd-click, Shift-click, checkbox) works
- [x] Recover tested with single + multiple mixed items; dialog confirms; list auto-refreshes
- [x] Delete Permanently tested with single + multiple mixed items; red warning dialog; list auto-refreshes
- [x] Non-trash modes (Library / Jobs / Legacy) unchanged — existing single-item DELETE flow still works