### PR TITLE
Add embedded bridge for native app integration

### DIFF
--- a/cmd/rescale-int-bridge/main.go
+++ b/cmd/rescale-int-bridge/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/rescale/rescale-int/internal/cli"
+	"github.com/rescale/rescale-int/internal/version"
+	"github.com/rescale/rescale-int/internal/wailsapp"
+)
+
+func main() {
+	host := flag.String("host", "127.0.0.1", "HTTP bind host")
+	port := flag.Int("port", 0, "HTTP bind port")
+	flag.Parse()
+
+	if *port <= 0 {
+		fmt.Fprintln(os.Stderr, "--port is required")
+		os.Exit(2)
+	}
+
+	cli.Version = version.Version
+	cli.BuildTime = version.BuildTime
+
+	addr := fmt.Sprintf("%s:%d", *host, *port)
+	if err := wailsapp.RunEmbeddedBridge(addr); err != nil {
+		fmt.Fprintf(os.Stderr, "embedded bridge failed: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/wailsapp/app.go
+++ b/internal/wailsapp/app.go
@@ -64,9 +64,9 @@ type App struct {
 
 	// State helper shared with Tray and CLI; owns the canonical (installation,
 	// per-user) state model plus the 10s transient-pending timeout.
-	stateMu     sync.Mutex
-	stateComp   *service.Computer
-	priorState  service.State
+	stateMu    sync.Mutex
+	stateComp  *service.Computer
+	priorState service.State
 }
 
 // ensureStateComputer lazily constructs the shared service.Computer. Called
@@ -84,6 +84,60 @@ func (a *App) ensureStateComputer() *service.Computer {
 // NewApp creates a new Wails application instance.
 func NewApp() *App {
 	return &App{}
+}
+
+func initWailsLogger(name string) {
+	wailsLogger = logging.NewLogger(name, nil)
+	if os.Getenv("RESCALE_DEBUG") != "" {
+		logging.SetGlobalLevel(zerolog.DebugLevel)
+		wailsLogger.Info().Msg("Debug logging enabled via RESCALE_DEBUG")
+	} else {
+		logging.SetGlobalLevel(zerolog.WarnLevel)
+	}
+}
+
+func newConfiguredApp(configFile string) (*App, error) {
+	cfg, err := loadConfiguration(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	engine, err := core.NewEngine(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create engine: %w", err)
+	}
+
+	app := NewApp()
+	app.engine = engine
+	app.config = cfg
+	return app, nil
+}
+
+func (a *App) startSharedBackend(ctx context.Context) {
+	a.ctx = ctx
+
+	if a.engine != nil {
+		a.reporter = reporting.NewReporter(a.engine.Events())
+		cloud.SetEventBus(a.engine.Events())
+		ratelimit.GlobalStore().SetCoordinatorEnsurer(coordinator.EnsureCoordinatorClient)
+	}
+
+	if a.config != nil {
+		cloud.SetDetailedLogging(a.config.DetailedLogging)
+	}
+	config.RunStartupMigrations(wailsLogger, config.ScopeCurrentUser, nil)
+	a.autoPersistFromEnv()
+}
+
+func newEmbeddedApp() (*App, error) {
+	initWailsLogger("wails-embedded")
+	app, err := newConfiguredApp("")
+	if err != nil {
+		return nil, err
+	}
+	app.startSharedBackend(context.Background())
+	wailsLogger.Info().Msg("Embedded application started")
+	return app, nil
 }
 
 // Unified logging helper that logs to terminal, Activity Logs tab, and log file.
@@ -159,7 +213,7 @@ func (a *App) ClearCatalogCache() {
 // startup is called when the app starts. The context is saved
 // so we can call the Wails runtime methods.
 func (a *App) startup(ctx context.Context) {
-	a.ctx = ctx
+	a.startSharedBackend(ctx)
 
 	// Initialize event bridge if engine exists
 	if a.engine != nil {
@@ -167,14 +221,6 @@ func (a *App) startup(ctx context.Context) {
 		if err := a.eventBridge.Start(); err != nil {
 			wailsLogger.Error().Err(err).Msg("Failed to start event bridge")
 		}
-
-		a.reporter = reporting.NewReporter(a.engine.Events())
-
-		// Set EventBus for timing infrastructure so timing logs appear in Activity tab
-		cloud.SetEventBus(a.engine.Events())
-
-		// Wire cross-process rate limit coordinator (lazy — only spawns when GetLimiter is called)
-		ratelimit.GlobalStore().SetCoordinatorEnsurer(coordinator.EnsureCoordinatorClient)
 
 		// Route backend log.Printf to GUI Activity Logs via TeeWriter.
 		// This intercepts all stdlib log output and publishes to EventBus.
@@ -197,22 +243,8 @@ func (a *App) startup(ctx context.Context) {
 		})
 	}
 
-	// Initialize detailed logging from config
-	if a.config != nil {
-		cloud.SetDetailedLogging(a.config.DetailedLogging)
-	}
-
-	// Plan 2 path migrations (idempotent; current-user scope in GUI).
-	config.RunStartupMigrations(wailsLogger, config.ScopeCurrentUser, nil)
-
 	// Auto-launch tray companion if available (Windows only, no-op on other platforms)
 	go a.launchTrayIfNeeded()
-
-	// If an API key was resolved from the environment but no token file
-	// exists, persist it now so a later daemon/service handoff can read it.
-	// This closes the env-var→service gap that previously required an
-	// explicit Save click.
-	a.autoPersistFromEnv()
 
 	wailsLogger.Info().Msg("Wails application started")
 }
@@ -263,7 +295,7 @@ func (a *App) beforeClose(ctx context.Context) bool {
 
 // shutdown is called at application termination.
 func (a *App) shutdown(ctx context.Context) {
-	wailsLogger.Info().Msg("Wails application shutting down")
+	wailsLogger.Info().Msg("Interlink application shutting down")
 
 	if a.eventBridge != nil {
 		a.eventBridge.Stop()
@@ -289,16 +321,7 @@ func Run(args []string) error {
 	}
 	defer CloseFileLogger()
 
-	// Initialize Wails logger
-	wailsLogger = logging.NewLogger("wails", nil)
-
-	// Set log level based on RESCALE_DEBUG environment variable
-	if os.Getenv("RESCALE_DEBUG") != "" {
-		logging.SetGlobalLevel(zerolog.DebugLevel)
-		wailsLogger.Info().Msg("Debug logging enabled via RESCALE_DEBUG")
-	} else {
-		logging.SetGlobalLevel(zerolog.WarnLevel)
-	}
+	initWailsLogger("wails")
 
 	// Check for display on Linux
 	if runtime.GOOS == "linux" {
@@ -309,22 +332,10 @@ func Run(args []string) error {
 		}
 	}
 
-	// Load configuration
-	cfg, err := loadConfiguration("")
+	app, err := newConfiguredApp("")
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return err
 	}
-
-	// Create engine
-	engine, err := core.NewEngine(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to create engine: %w", err)
-	}
-
-	// Create application
-	app := NewApp()
-	app.engine = engine
-	app.config = cfg
 
 	// Window title
 	windowTitle := fmt.Sprintf("Rescale Interlink %s", cli.Version)

--- a/internal/wailsapp/embedded_bridge.go
+++ b/internal/wailsapp/embedded_bridge.go
@@ -1,0 +1,206 @@
+package wailsapp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type embeddedRPCRequest struct {
+	Method string            `json:"method"`
+	Args   []json.RawMessage `json:"args"`
+}
+
+type embeddedRPCResponse struct {
+	Result any    `json:"result,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+type embeddedEventRecord struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	Data any    `json:"data"`
+}
+
+type embeddedEventStore struct {
+	mu     sync.RWMutex
+	nextID int64
+	events []embeddedEventRecord
+}
+
+func (s *embeddedEventStore) append(name string, data any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.nextID++
+	s.events = append(s.events, embeddedEventRecord{
+		ID:   s.nextID,
+		Name: name,
+		Data: data,
+	})
+	if len(s.events) > 1000 {
+		s.events = s.events[len(s.events)-1000:]
+	}
+}
+
+func (s *embeddedEventStore) after(id int64) []embeddedEventRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	records := make([]embeddedEventRecord, 0, len(s.events))
+	for _, record := range s.events {
+		if record.ID > id {
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+// RunEmbeddedBridge exposes App bindings as loopback JSON RPC for an embedded
+// Interlink frontend running inside another native app.
+func RunEmbeddedBridge(addr string) error {
+	app, err := newEmbeddedApp()
+	if err != nil {
+		return err
+	}
+	defer app.shutdown(app.ctx)
+
+	eventStore := &embeddedEventStore{}
+	if err := startEmbeddedEventBridge(app, eventStore); err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		writeEmbeddedJSON(w, http.StatusOK, map[string]any{
+			"ok":   true,
+			"time": time.Now().Format(time.RFC3339Nano),
+		})
+	})
+	mux.HandleFunc("/rpc", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeEmbeddedJSON(w, http.StatusMethodNotAllowed, embeddedRPCResponse{Error: "POST required"})
+			return
+		}
+
+		var req embeddedRPCRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeEmbeddedJSON(w, http.StatusBadRequest, embeddedRPCResponse{Error: err.Error()})
+			return
+		}
+
+		result, err := callEmbeddedMethod(app, req.Method, req.Args)
+		if err != nil {
+			writeEmbeddedJSON(w, http.StatusOK, embeddedRPCResponse{Error: err.Error()})
+			return
+		}
+		writeEmbeddedJSON(w, http.StatusOK, embeddedRPCResponse{Result: result})
+	})
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		after := int64(0)
+		if raw := r.URL.Query().Get("after"); raw != "" {
+			parsed, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil {
+				writeEmbeddedJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			after = parsed
+		}
+		writeEmbeddedJSON(w, http.StatusOK, map[string]any{"events": eventStore.after(after)})
+	})
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return server.ListenAndServe()
+}
+
+func callEmbeddedMethod(app *App, method string, args []json.RawMessage) (result any, err error) {
+	if method == "" {
+		return nil, errors.New("method is required")
+	}
+
+	fn := reflect.ValueOf(app).MethodByName(method)
+	if !fn.IsValid() {
+		return nil, fmt.Errorf("unknown Interlink method: %s", method)
+	}
+
+	fnType := fn.Type()
+	if len(args) != fnType.NumIn() {
+		return nil, fmt.Errorf("%s expects %d args, got %d", method, fnType.NumIn(), len(args))
+	}
+
+	values := make([]reflect.Value, fnType.NumIn())
+	for i := range values {
+		argType := fnType.In(i)
+		argValue := reflect.New(argType)
+		if err := json.Unmarshal(args[i], argValue.Interface()); err != nil {
+			return nil, fmt.Errorf("%s arg %d: %w", method, i+1, err)
+		}
+		values[i] = argValue.Elem()
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("%s panicked: %v", method, recovered)
+		}
+	}()
+
+	out := fn.Call(values)
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	last := out[len(out)-1]
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	if last.Type().Implements(errorType) {
+		if !last.IsNil() {
+			return nil, last.Interface().(error)
+		}
+		out = out[:len(out)-1]
+	}
+
+	if len(out) == 0 {
+		return nil, nil
+	}
+	if len(out) == 1 {
+		return out[0].Interface(), nil
+	}
+
+	results := make([]any, len(out))
+	for i, value := range out {
+		results[i] = value.Interface()
+	}
+	return results, nil
+}
+
+func startEmbeddedEventBridge(app *App, store *embeddedEventStore) error {
+	if app.engine == nil || app.engine.Events() == nil {
+		return nil
+	}
+
+	app.eventBridge = newEventBridge(
+		app.ctx,
+		app.engine.Events(),
+		func(_ context.Context, name string, data any) {
+			store.append(name, data)
+		},
+	)
+	return app.eventBridge.Start()
+}
+
+func writeEmbeddedJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		wailsLogger.Error().Err(err).Msg("failed to write embedded bridge JSON response")
+	}
+}

--- a/internal/wailsapp/event_bridge.go
+++ b/internal/wailsapp/event_bridge.go
@@ -1,4 +1,4 @@
-// Package wailsapp provides the event bridge between Go EventBus and Wails runtime.
+// Package wailsapp provides the event bridge between Go EventBus and UI runtimes.
 package wailsapp
 
 import (
@@ -12,11 +12,14 @@ import (
 	"github.com/rescale/rescale-int/internal/events"
 )
 
-// EventBridge forwards events from internal EventBus to Wails runtime.
+type eventEmitFunc func(context.Context, string, any)
+
+// EventBridge forwards events from internal EventBus to a frontend runtime.
 type EventBridge struct {
 	ctx          context.Context
 	eventBus     *events.EventBus
 	subscription <-chan events.Event
+	emit         eventEmitFunc
 
 	// Throttling for high-frequency events
 	lastProgress     map[string]time.Time
@@ -30,9 +33,20 @@ type EventBridge struct {
 
 // NewEventBridge creates a new event bridge.
 func NewEventBridge(ctx context.Context, eventBus *events.EventBus) *EventBridge {
+	return newEventBridge(ctx, eventBus, func(ctx context.Context, name string, data any) {
+		runtime.EventsEmit(ctx, name, data)
+	})
+}
+
+func newEventBridge(
+	ctx context.Context,
+	eventBus *events.EventBus,
+	emit eventEmitFunc,
+) *EventBridge {
 	return &EventBridge{
 		ctx:              ctx,
 		eventBus:         eventBus,
+		emit:             emit,
 		lastProgress:     make(map[string]time.Time),
 		progressInterval: 100 * time.Millisecond, // Throttle to 10 updates/sec
 		stopC:            make(chan struct{}),
@@ -107,19 +121,19 @@ func (eb *EventBridge) forwardEvent(event events.Event) {
 		if eb.shouldThrottle(e.JobName) {
 			return
 		}
-		runtime.EventsEmit(eb.ctx, "interlink:progress", progressEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:progress", progressEventToDTO(e))
 
 	case *events.LogEvent:
-		runtime.EventsEmit(eb.ctx, "interlink:log", logEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:log", logEventToDTO(e))
 
 	case *events.StateChangeEvent:
-		runtime.EventsEmit(eb.ctx, "interlink:state_change", stateChangeEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:state_change", stateChangeEventToDTO(e))
 
 	case *events.ErrorEvent:
-		runtime.EventsEmit(eb.ctx, "interlink:error", errorEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:error", errorEventToDTO(e))
 
 	case *events.CompleteEvent:
-		runtime.EventsEmit(eb.ctx, "interlink:complete", completeEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:complete", completeEventToDTO(e))
 
 	case *events.TransferEvent:
 		// Only throttle PROGRESS events — never throttle terminal states
@@ -130,27 +144,27 @@ func (eb *EventBridge) forwardEvent(event events.Event) {
 		if !isTerminalState && eb.shouldThrottle(e.TaskID) {
 			return
 		}
-		runtime.EventsEmit(eb.ctx, "interlink:transfer", transferEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:transfer", transferEventToDTO(e))
 
 	case *events.EnumerationEvent:
 		// Don't throttle these - they're infrequent and important for UX
-		runtime.EventsEmit(eb.ctx, "interlink:enumeration", enumerationEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:enumeration", enumerationEventToDTO(e))
 
 	case *events.ScanProgressEvent:
 		// Don't throttle - these are infrequent and important for UX
-		runtime.EventsEmit(eb.ctx, "interlink:scan_progress", scanProgressEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:scan_progress", scanProgressEventToDTO(e))
 
 	case *events.BatchProgressEvent:
 		// No throttling needed — ticker already limits to 1/sec per batch
-		runtime.EventsEmit(eb.ctx, "interlink:batch_progress", batchProgressEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:batch_progress", batchProgressEventToDTO(e))
 
 	case *events.ConfigChangedEvent:
 		// Forward credential changes so file browser can invalidate cache
-		runtime.EventsEmit(eb.ctx, "interlink:config_changed", configChangedEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:config_changed", configChangedEventToDTO(e))
 
 	case *events.ReportableErrorEvent:
 		// Reportable error events for safe error reporting — NOT throttled
-		runtime.EventsEmit(eb.ctx, "interlink:reportable_error", reportableErrorEventToDTO(e))
+		eb.emit(eb.ctx, "interlink:reportable_error", reportableErrorEventToDTO(e))
 	}
 }
 


### PR DESCRIPTION
## TBD
I'd rather not increase your maintenance burden. I might make this into a patch that I apply in the rescale-ai repo, instead of upstreaming it. This isn't needed for this repo, so probably it shouldn't live here.

## What this PR changes

This adds a small hidden “bridge” mode to Interlink so another desktop app can place the real Interlink experience inside one of its own tabs.

The main use case is the Rescale AI native app: instead of asking users to open a separate Interlink app window, Rescale AI can show Interlink directly inside its app.

For normal Interlink users, nothing should look or behave differently. The regular Interlink app still launches the same way.

## Why this is needed

Interlink is built as a native desktop app. Its screen is not just static web content; the UI talks to Interlink’s local backend for things like configuration, job setup, file browsing, transfers, logs, and connection status.

If another app simply embeds the Interlink UI without a backend, most of Interlink will not work.

This PR adds a small local-only bridge that lets a host app talk to the same Interlink backend that the normal Interlink app already uses.

## What is intentionally not included

This PR does not add Rescale AI-specific logic to Interlink.

It does not add a new cloud service.

It does not change Interlink’s normal user interface.

It does not require the Interlink team to package, launch, or manage the Rescale AI app.

## Maintenance burden

Expected burden should be low, but not zero.

The Interlink repo would own a small additional way to start Interlink: “run the backend without opening the Interlink window, and let another app display the UI.”

The bridge reuses Interlink’s existing backend startup path and existing event-delivery path. That is intentional: future Interlink changes should usually flow through automatically instead of requiring duplicate embedded-mode code.

The main times this could require maintenance are:

- if Interlink changes how its frontend talks to its backend
- if Interlink changes how app startup works
- if Interlink changes event/log/progress delivery in a way that affects the existing UI bridge
- if the host app reports that embedded Interlink no longer works after an Interlink upgrade

In those cases, the expected fix should be small and local to this bridge layer.

## Ownership boundary

Interlink owns only the generic bridge capability: “can Interlink run headless and answer local UI/backend calls?”

Rescale AI owns the actual embedding work: placing Interlink in a tab, launching/stopping the bridge, packaging it into the Rescale AI app, and handling any Rescale AI-specific UI.

That boundary is meant to keep ongoing Interlink ownership small.

## Tradeoff

The tradeoff is between a cleaner user experience and a small extra supported mode.

Benefit: users can access Interlink inside Rescale AI without switching apps.

Cost: Interlink gains one small local bridge entrypoint that should keep working as Interlink evolves.

My recommendation: this is reasonable to merge if we are comfortable treating embedded Interlink as a supported integration path for Rescale AI, with Rescale AI owning the app-level integration and Interlink owning only the generic bridge.

## Testing done

- Existing Interlink Wails app tests pass.
- The new bridge command builds.
- A live local smoke test started the bridge, confirmed health, and called `GetAppInfo`, which returned Interlink `v4.9.6`.
