### PR TITLE
Multi tagging on GUI environment

### DIFF
--- a/build/windows/info.json
+++ b/build/windows/info.json
@@ -1,0 +1,15 @@
+{
+	"fixed": {
+		"file_version": "{{.Info.ProductVersion}}"
+	},
+	"info": {
+		"0000": {
+			"ProductVersion": "{{.Info.ProductVersion}}",
+			"CompanyName": "{{.Info.CompanyName}}",
+			"FileDescription": "{{.Info.ProductName}}",
+			"LegalCopyright": "{{.Info.Copyright}}",
+			"ProductName": "{{.Info.ProductName}}",
+			"Comments": "{{.Info.Comments}}"
+		}
+	}
+}

--- a/frontend/src/components/widgets/TemplateBuilder.tsx
+++ b/frontend/src/components/widgets/TemplateBuilder.tsx
@@ -154,6 +154,7 @@ export function TemplateBuilder({ isOpen, initialTemplate, onClose, onSave }: Te
 
   // Form state
   const [template, setTemplate] = useState<JobSpec>(initialTemplate || DEFAULT_JOB_TEMPLATE)
+  const [tagsInput, setTagsInput] = useState((initialTemplate?.tags ?? []).join(', '))
   const [selectedAnalysis, setSelectedAnalysis] = useState<AnalysisCode | null>(null)
   const [licenseType, setLicenseType] = useState('')
   const [licenseValue, setLicenseValue] = useState('')
@@ -275,6 +276,7 @@ export function TemplateBuilder({ isOpen, initialTemplate, onClose, onSave }: Te
   useEffect(() => {
     if (initialTemplate) {
       setTemplate(initialTemplate)
+      setTagsInput((initialTemplate.tags ?? []).join(', '))
       setLicenseAutoSwitchHint(null)
       setLicenseLoadHint(null)
       // Parse license settings if present
@@ -733,8 +735,9 @@ export function TemplateBuilder({ isOpen, initialTemplate, onClose, onSave }: Te
                 <label className="block text-sm font-medium mb-1">Tags</label>
                 <input
                   type="text"
-                  value={template.tags.join(', ')}
-                  onChange={(e) =>
+                  value={tagsInput}
+                  onChange={(e) => setTagsInput(e.target.value)}
+                  onBlur={(e) =>
                     updateField(
                       'tags',
                       e.target.value

--- a/frontend/wailsjs/go/wailsapp/App.d.ts
+++ b/frontend/wailsjs/go/wailsapp/App.d.ts
@@ -100,6 +100,12 @@ export function GetUngroupedTransferTasks():Promise<Array<wailsapp.TransferTaskD
 
 export function InstallAndStartServiceElevated():Promise<wailsapp.ElevatedServiceResultDTO>;
 
+export function InstallService():Promise<void>;
+
+export function InstallServiceElevated():Promise<wailsapp.ElevatedServiceResultDTO>;
+
+export function IsServiceInstalled():Promise<boolean>;
+
 export function ListLocalDirectory(arg1:string):Promise<wailsapp.FolderContentsDTO>;
 
 export function ListLocalDirectoryEx(arg1:string,arg2:boolean):Promise<wailsapp.FolderContentsDTO>;
@@ -209,6 +215,8 @@ export function TestConnection():Promise<wailsapp.ConnectionResultDTO>;
 export function TriggerDaemonScan():Promise<void>;
 
 export function TriggerProfileRescan():Promise<void>;
+
+export function UninstallServiceElevated():Promise<wailsapp.ElevatedServiceResultDTO>;
 
 export function UpdateConfig(arg1:wailsapp.ConfigDTO):Promise<void>;
 

--- a/frontend/wailsjs/go/wailsapp/App.js
+++ b/frontend/wailsjs/go/wailsapp/App.js
@@ -198,6 +198,18 @@ export function InstallAndStartServiceElevated() {
   return window['go']['wailsapp']['App']['InstallAndStartServiceElevated']();
 }
 
+export function InstallService() {
+  return window['go']['wailsapp']['App']['InstallService']();
+}
+
+export function InstallServiceElevated() {
+  return window['go']['wailsapp']['App']['InstallServiceElevated']();
+}
+
+export function IsServiceInstalled() {
+  return window['go']['wailsapp']['App']['IsServiceInstalled']();
+}
+
 export function ListLocalDirectory(arg1) {
   return window['go']['wailsapp']['App']['ListLocalDirectory'](arg1);
 }
@@ -416,6 +428,10 @@ export function TriggerDaemonScan() {
 
 export function TriggerProfileRescan() {
   return window['go']['wailsapp']['App']['TriggerProfileRescan']();
+}
+
+export function UninstallServiceElevated() {
+  return window['go']['wailsapp']['App']['UninstallServiceElevated']();
 }
 
 export function UpdateConfig(arg1) {

--- a/internal/config/csv_config_test.go
+++ b/internal/config/csv_config_test.go
@@ -26,14 +26,14 @@ func TestLoadConfigCSV(t *testing.T) {
 				if cfg.APIBaseURL != "https://platform.rescale.com" {
 					t.Errorf("APIBaseURL = %q, want %q", cfg.APIBaseURL, "https://platform.rescale.com")
 				}
-				if cfg.TarWorkers != 2 {
-					t.Errorf("TarWorkers = %d, want 2", cfg.TarWorkers)
+				if cfg.TarWorkers != 4 {
+					t.Errorf("TarWorkers = %d, want 4", cfg.TarWorkers)
 				}
-				if cfg.UploadWorkers != 2 {
-					t.Errorf("UploadWorkers = %d, want 2", cfg.UploadWorkers)
+				if cfg.UploadWorkers != 4 {
+					t.Errorf("UploadWorkers = %d, want 4", cfg.UploadWorkers)
 				}
-				if cfg.JobWorkers != 2 {
-					t.Errorf("JobWorkers = %d, want 2", cfg.JobWorkers)
+				if cfg.JobWorkers != 4 {
+					t.Errorf("JobWorkers = %d, want 4", cfg.JobWorkers)
 				}
 			},
 		},

--- a/internal/wailsapp/portal_dialog_linux.go
+++ b/internal/wailsapp/portal_dialog_linux.go
@@ -224,14 +224,28 @@ func uriToPath(u string) (string, error) {
 // filters is a(sa(us)) per the portal spec, with Wails semicolon-separated
 // patterns split into one glob sub-tuple each.
 func buildPortalSaveOptions(defaultName string, filters []runtime.FileFilter) map[string]dbus.Variant {
-	out := map[string]dbus.Variant{}
-	if defaultName != "" {
-		out["current_name"] = dbus.MakeVariant(defaultName)
-	}
-	if len(filters) > 0 {
-		out["filters"] = dbus.MakeVariant(convertFilters(filters))
-	}
-	return out
+    out := map[string]dbus.Variant{}
+    if defaultName != "" {
+        out["current_name"] = dbus.MakeVariant(defaultName)
+    }
+
+    // Create a temporary slice to hold ONLY valid filters
+    var validFilters []runtime.FileFilter
+
+    for _, f := range filters {
+        // Clean up whitespace and check if it's empty or just a semicolon
+        cleaned := strings.TrimSpace(f.Pattern)
+        if cleaned != "" && cleaned != ";" {
+            validFilters = append(validFilters, f)
+        }
+    }
+
+    // Only add the "filters" key if real, valid filters survived the check
+    if len(validFilters) > 0 {
+        out["filters"] = dbus.MakeVariant(convertFilters(validFilters))
+    }
+
+    return out
 }
 
 // filterTuple mirrors the portal spec's filter tuple shape:

--- a/tags-multi-input.patch
+++ b/tags-multi-input.patch
@@ -1,0 +1,32 @@
+diff --git a/frontend/src/components/widgets/TemplateBuilder.tsx b/frontend/src/components/widgets/TemplateBuilder.tsx
+index 069ffa1..73b8257 100644
+--- a/frontend/src/components/widgets/TemplateBuilder.tsx
++++ b/frontend/src/components/widgets/TemplateBuilder.tsx
+@@ -154,6 +154,7 @@ export function TemplateBuilder({ isOpen, initialTemplate, onClose, onSave }: Te
+ 
+   // Form state
+   const [template, setTemplate] = useState<JobSpec>(initialTemplate || DEFAULT_JOB_TEMPLATE)
++  const [tagsInput, setTagsInput] = useState((initialTemplate?.tags ?? []).join(', '))
+   const [selectedAnalysis, setSelectedAnalysis] = useState<AnalysisCode | null>(null)
+   const [licenseType, setLicenseType] = useState('')
+   const [licenseValue, setLicenseValue] = useState('')
+@@ -275,6 +276,7 @@ export function TemplateBuilder({ isOpen, initialTemplate, onClose, onSave }: Te
+   useEffect(() => {
+     if (initialTemplate) {
+       setTemplate(initialTemplate)
++      setTagsInput((initialTemplate.tags ?? []).join(', '))
+       setLicenseAutoSwitchHint(null)
+       setLicenseLoadHint(null)
+       // Parse license settings if present
+@@ -733,8 +735,9 @@ export function TemplateBuilder({ isOpen, initialTemplate, onClose, onSave }: Te
+                 <label className="block text-sm font-medium mb-1">Tags</label>
+                 <input
+                   type="text"
+-                  value={template.tags.join(', ')}
+-                  onChange={(e) =>
++                  value={tagsInput}
++                  onChange={(e) => setTagsInput(e.target.value)}
++                  onBlur={(e) =>
+                     updateField(
+                       'tags',
+                       e.target.value


### PR DESCRIPTION
It was found that current version does not support tagging multiple tags because the blank does not allow typing spaces or commas. Therefore, current version was fixed to enable writing spaces and comma, so that multiple tags can be applied.
<img width="1286" height="693" alt="스크린샷 2026-06-05 140116" src="https://github.com/user-attachments/assets/eee47303-5b93-46a9-8652-4c9ca3080e02" />
