### PR TITLE
Fix GitHub AI code-quality findings

### DIFF
--- a/build/build_dist.ps1
+++ b/build/build_dist.ps1
@@ -2,6 +2,10 @@ param (
     [string]$ReleaseTag = $env:RELEASE_TAG
 )
 
+# Fail fast on any error, including the early setup steps below.
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
 # Set up paths
 $WorkDir = $PWD.Path
 $BuildDir = Join-Path $WorkDir "_build"
@@ -19,9 +23,6 @@ Write-Host "Build directory: $BuildDir"
 Write-Host "Bin directory: $BinDir"
 
 Set-Location $BuildDir
-
-$ErrorActionPreference = "Stop"
-$ProgressPreference = "SilentlyContinue"
 
 # =============================================================================
 # Step 1: Install Go 1.26.3
@@ -87,7 +88,7 @@ Write-Host $dotnetResult
 # Step 3: Install WiX Toolset v4
 # =============================================================================
 Write-Host ""
-Write-Host "[4/7] Installing WiX Toolset v4..."
+Write-Host "[3/7] Installing WiX Toolset v4..."
 
 # Temporarily allow errors since dotnet outputs info to stderr
 $prevErrorAction = $ErrorActionPreference
@@ -127,7 +128,7 @@ Write-Host $wixVersionResult
 # Step 3.5: Install Node.js and Wails CLI (required for GUI build)
 # =============================================================================
 Write-Host ""
-Write-Host "[4.5/7] Installing Node.js and Wails CLI..."
+Write-Host "[3.5/7] Installing Node.js and Wails CLI..."
 
 # Install Node.js via Chocolatey
 $prevErrorAction = $ErrorActionPreference
@@ -171,7 +172,7 @@ Write-Host $wailsResult
 # Step 4: Build Wails Application
 # =============================================================================
 Write-Host ""
-Write-Host "[5/7] Building Wails application with FIPS 140-3..."
+Write-Host "[4/7] Building Wails application with FIPS 140-3..."
 
 # On GitHub Actions, the repo is already checked out to the workspace root.
 # On Rescale HPC, the script clones into $env:REPO_NAME and must cd into it.
@@ -193,7 +194,7 @@ $ErrorActionPreference = "Continue"
 cmd /c "npm install 2>&1" | Out-Host
 $npmExitCode = $LASTEXITCODE
 $ErrorActionPreference = $prevErrorAction
-Set-Location ..
+Set-Location $WorkDir
 
 if ($npmExitCode -ne 0) {
     Write-Host "Warning: npm install returned exit code $npmExitCode (may be non-fatal warnings)"
@@ -251,7 +252,7 @@ Get-ChildItem $BinDir
 # Step 4.5: Download and Bundle WebView2 Fixed Version Runtime
 # =============================================================================
 Write-Host ""
-Write-Host "[5.5/7] Bundling WebView2 Fixed Version Runtime..."
+Write-Host "[4.5/7] Bundling WebView2 Fixed Version Runtime..."
 
 $WebView2Dir = Join-Path $BinDir "webview2"
 New-Item -ItemType Directory -Force -Path $WebView2Dir | Out-Null
@@ -356,7 +357,7 @@ if ($hasWebView2) {
 # Step 5: Create Support Files
 # =============================================================================
 Write-Host ""
-Write-Host "[6/7] Creating support files..."
+Write-Host "[5/7] Creating support files..."
 
 $ReadmeContent = @"
 Rescale Interlink $($ReleaseTag)

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	nethttp "net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -280,12 +281,17 @@ func proxyFuncWithBypass(proxyURL *url.URL, noProxy string) func(*nethttp.Reques
 		NoProxy:    noProxy,
 	}
 	proxyFunc := cfg.ProxyFunc()
+	// Per-request routing logs are noisy on concurrent transfer workloads; gate
+	// them behind RESCALE_DEBUG. Evaluated once here, not per request.
+	proxyDebug := os.Getenv("RESCALE_DEBUG") != ""
 	return func(req *nethttp.Request) (*url.URL, error) {
 		result, err := proxyFunc(req.URL)
-		if result == nil {
-			log.Printf("[PROXY] Bypass: %s (direct connection)", req.URL.Host)
-		} else {
-			log.Printf("[PROXY] Proxied: %s → %s", req.URL.Host, result.Host)
+		if proxyDebug {
+			if result == nil {
+				log.Printf("[PROXY] Bypass: %s (direct connection)", req.URL.Host)
+			} else {
+				log.Printf("[PROXY] Proxied: %s → %s", req.URL.Host, result.Host)
+			}
 		}
 		return result, err
 	}

--- a/internal/mesainit/init_windows.go
+++ b/internal/mesainit/init_windows.go
@@ -123,7 +123,11 @@ func tryExtractAndReexec() bool {
 		// Don't return error - the new process may have already run and exited
 	}
 
-	// Exit this process - the re-exec'd process is handling things now
+	// Exit this process - the re-exec'd process is handling things now.
+	// If the process never started, ProcessState is nil; exit non-zero rather than panic.
+	if cmd.ProcessState == nil {
+		os.Exit(1)
+	}
 	os.Exit(cmd.ProcessState.ExitCode())
 	return true // Never reached
 }

--- a/internal/wailsapp/api_key_source_bindings.go
+++ b/internal/wailsapp/api_key_source_bindings.go
@@ -169,22 +169,15 @@ func legacyAPIKeyPresent() bool {
 }
 
 func removeSavedAPIKeyTokenFiles() (int, error) {
-	removed := 0
-	seen := map[string]bool{}
-	for i := 0; i < 3; i++ {
-		tokenPath := config.GetDefaultTokenPath()
-		if tokenPath == "" || seen[tokenPath] {
-			break
-		}
-		seen[tokenPath] = true
-
-		if err := os.Remove(tokenPath); err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return removed, err
-		}
-		removed++
+	tokenPath := config.GetDefaultTokenPath()
+	if tokenPath == "" {
+		return 0, nil
 	}
-	return removed, nil
+	if err := os.Remove(tokenPath); err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return 1, nil
 }

--- a/internal/wailsapp/reporting_bindings.go
+++ b/internal/wailsapp/reporting_bindings.go
@@ -84,7 +84,7 @@ func (a *App) SaveErrorReport(reportJSON string) (path string, err error) {
 		return "", fmt.Errorf(appNotReadyError)
 	}
 
-	suggestedName := fmt.Sprintf("rescale-error-report-%s.json", time.Now().Format("2006-01-02T150405"))
+	suggestedName := fmt.Sprintf("rescale-error-report-%s.json", time.Now().Format("2006-01-02T15-04-05"))
 	path, err = portalAwareSaveFile(a.ctx, "SaveErrorReport", runtime.SaveDialogOptions{
 		DefaultFilename: suggestedName,
 		Title:           "Save Error Report",
@@ -127,7 +127,7 @@ func (a *App) SaveLogExport(content string) (path string, err error) {
 		return "", fmt.Errorf(appNotReadyError)
 	}
 
-	suggestedName := fmt.Sprintf("interlink-activity-%s.log", time.Now().Format("2006-01-02"))
+	suggestedName := fmt.Sprintf("interlink-activity-%s.log", time.Now().Format("2006-01-02T15-04-05"))
 	path, err = portalAwareSaveFile(a.ctx, "SaveLogExport", runtime.SaveDialogOptions{
 		DefaultFilename: suggestedName,
 		Title:           "Export Activity Logs",


### PR DESCRIPTION
## Summary

Addresses all 8 findings from the GitHub Code Quality (AI) tab on recently-changed files. These are robustness and consistency cleanups — one genuine latent bug, the rest small quality improvements. No release; dev-tooling/source cleanup only.

## Changes

- **`internal/mesainit/init_windows.go`** — Guard `cmd.ProcessState == nil` before calling `.ExitCode()`. If the re-exec'd process fails to *start*, `ProcessState` is nil and the call panics. Exit non-zero instead. *(the one real bug)*
- **`internal/http/proxy.go`** — Gate the per-request proxy routing logs behind `RESCALE_DEBUG` (the existing debug convention). Removes log spam on concurrent transfer workloads; env var read once, not per request.
- **`internal/wailsapp/api_key_source_bindings.go`** — Simplify `removeSavedAPIKeyTokenFiles` to a single attempt. `GetDefaultTokenPath()` is deterministic, so the 3-iteration loop + `seen` map could only ever execute once. Behavior-identical, `(int, error)` contract preserved.
- **`internal/wailsapp/reporting_bindings.go`** — Use filename-safe timestamp separators (`15-04-05`, not `150405`) for the error-report name, and align the log-export filename to date+time to avoid same-day collisions. Affects only the pre-filled name in the Save dialog.
- **`build/build_dist.ps1`** — Move `$ErrorActionPreference = "Stop"` to the top so early setup steps fail fast; resequence the `[N/7]` step labels to match the comment headers; replace relative `Set-Location ..` with absolute `Set-Location $WorkDir`. No change to the FIPS/PATH-ordering logic.

## Test plan

- [x] `go build ./...`, `go vet` (changed packages) — clean
- [x] `GOOS=windows` cross-compile of the Windows-only files — clean
- [x] `go test ./internal/http/... ./internal/wailsapp/...` — pass
- [x] Full Wails build (macOS arm64), frontend + backend — succeeds
- [ ] Windows-only runtime paths (init_windows.go, build_dist.ps1) exercised on next Windows build