### PR TITLE
feat: added back button on single job tab between step one and two

### DIFF
--- a/frontend/src/components/tabs/SingleJobTab.tsx
+++ b/frontend/src/components/tabs/SingleJobTab.tsx
@@ -846,23 +846,31 @@ export function SingleJobTab() {
             )}
           </div>
 
-          {/* Continue button */}
-          <button
-            onClick={() => {
-              if (sjStore.isInputsValid()) {
-                sjStore.setState('inputsReady')
-              }
-            }}
-            disabled={!sjStore.isInputsValid()}
-            className={clsx(
-              'flex items-center gap-2 px-4 py-2 rounded',
-              sjStore.isInputsValid()
-                ? 'bg-blue-500 text-white hover:bg-blue-600'
-                : 'bg-gray-300 dark:bg-gray-600 text-gray-500 cursor-not-allowed'
-            )}
-          >
-            Continue
-          </button>
+          {/* Navigation buttons */}
+          <div className="flex gap-4">
+            <button
+              onClick={() => sjStore.setState('initial')}
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              Back
+            </button>
+            <button
+              onClick={() => {
+                if (sjStore.isInputsValid()) {
+                  sjStore.setState('inputsReady')
+                }
+              }}
+              disabled={!sjStore.isInputsValid()}
+              className={clsx(
+                'flex items-center gap-2 px-4 py-2 rounded',
+                sjStore.isInputsValid()
+                  ? 'bg-blue-500 text-white hover:bg-blue-600'
+                  : 'bg-gray-300 dark:bg-gray-600 text-gray-500 cursor-not-allowed'
+              )}
+            >
+              Continue
+            </button>
+          </div>
         </div>
       )
     }


### PR DESCRIPTION
I added a button based on customer's request. They asked if they can add back button within single job tab to go back to first step. When they chose wrong json file for configuration, they need to revert the decision and re-select another json file. Therefore I added a back button to go back to step one.

<img width="1286" height="693" alt="image" src="https://github.com/user-attachments/assets/d6d5bef4-f260-4152-9c3a-16f97f2b34d9" />
